### PR TITLE
Improve Design System implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,9 +34,11 @@
         "rollup-plugin-livereload": "^2.0.0",
         "rollup-plugin-svelte": "^7.0.0",
         "rollup-plugin-terser": "^7.0.0",
+        "sass": "^1.43.4",
         "sirv-cli": "^1.0.0",
         "svelte": "^3.44.1",
         "svelte-loader": "^3.1.2",
+        "svelte-preprocess": "^4.9.8",
         "topojson-client": "^3.1.0"
       }
     },
@@ -6647,6 +6649,12 @@
       "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
       "dev": true
     },
+    "node_modules/@types/pug": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pug/-/pug-2.0.5.tgz",
+      "integrity": "sha512-LOnASQoeNZMkzexRuyqcBBDZ6rS+rQxUMkmj5A0PkhhiSZivLIuz6Hxyr1mkGoEZEkk66faROmpMi4fFkrKsBA==",
+      "dev": true
+    },
     "node_modules/@types/qs": {
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
@@ -6692,6 +6700,15 @@
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
       "integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/sass": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@types/sass/-/sass-1.43.0.tgz",
+      "integrity": "sha512-DPSXNJ1rYLo88GyF9tuB4bsYGfpKI1a4+wOQmc+LI1SUoocm9QLRSpz0GxxuyjmJsYFIQo/dDlRSSpIXngff+w==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -8152,6 +8169,15 @@
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4",
         "isarray": "^1.0.0"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "dev": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/buffer-from": {
@@ -9813,6 +9839,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/detect-indent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/detect-port": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.3.0.tgz",
@@ -10405,6 +10440,12 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/es6-promise": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+      "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=",
+      "dev": true
     },
     "node_modules/es6-shim": {
       "version": "0.35.6",
@@ -14603,6 +14644,15 @@
         "dom-walk": "^0.1.0"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -17726,6 +17776,30 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
+    "node_modules/sander": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/sander/-/sander-0.5.1.tgz",
+      "integrity": "sha1-dB4kXiMfB8r7b98PEzrfohalAq0=",
+      "dev": true,
+      "dependencies": {
+        "es6-promise": "^3.1.2",
+        "graceful-fs": "^4.1.3",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.2"
+      }
+    },
+    "node_modules/sander/node_modules/mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/sane": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/sane/-/sane-4.1.0.tgz",
@@ -17906,6 +17980,21 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sass": {
+      "version": "1.43.4",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.43.4.tgz",
+      "integrity": "sha512-/ptG7KE9lxpGSYiXn7Ar+lKOv37xfWsZRtFYal2QHNigyVQDx685VFT/h7ejVr+R8w7H4tmUgtulsKl5YpveOg==",
+      "dev": true,
+      "dependencies": {
+        "chokidar": ">=3.0.0 <4.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=8.9.0"
       }
     },
     "node_modules/scheduler": {
@@ -18492,6 +18581,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sorcery": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/sorcery/-/sorcery-0.10.0.tgz",
+      "integrity": "sha1-iukK19fLBfxZ8asMY3hF1cFaUrc=",
+      "dev": true,
+      "dependencies": {
+        "buffer-crc32": "^0.2.5",
+        "minimist": "^1.2.0",
+        "sander": "^0.5.0",
+        "sourcemap-codec": "^1.3.0"
+      },
+      "bin": {
+        "sorcery": "bin/index.js"
+      }
+    },
     "node_modules/sort-keys": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
@@ -19055,6 +19159,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -19142,7 +19258,6 @@
       "version": "3.44.1",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.44.1.tgz",
       "integrity": "sha512-4DrCEJoBvdR689efHNSxIQn2pnFwB7E7j2yLEJtHE/P8hxwZWIphCtJ8are7bjl/iVMlcEf5uh5pJ68IwR09vQ==",
-      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -19174,6 +19289,72 @@
       },
       "peerDependencies": {
         "svelte": ">3.0.0"
+      }
+    },
+    "node_modules/svelte-preprocess": {
+      "version": "4.9.8",
+      "resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.9.8.tgz",
+      "integrity": "sha512-EQS/oRZzMtYdAprppZxY3HcysKh11w54MgA63ybtL+TAZ4hVqYOnhw41JVJjWN9dhPnNjjLzvbZ2tMhTsla1Og==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@types/pug": "^2.0.4",
+        "@types/sass": "^1.16.0",
+        "detect-indent": "^6.0.0",
+        "magic-string": "^0.25.7",
+        "sorcery": "^0.10.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 9.11.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.10.2",
+        "coffeescript": "^2.5.1",
+        "less": "^3.11.3",
+        "postcss": "^7 || ^8",
+        "postcss-load-config": "^2.1.0 || ^3.0.0",
+        "pug": "^3.0.0",
+        "sass": "^1.26.8",
+        "stylus": "^0.54.7",
+        "sugarss": "^2.0.0",
+        "svelte": "^3.23.0",
+        "typescript": "^3.9.5 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "coffeescript": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "node-sass": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "postcss-load-config": {
+          "optional": true
+        },
+        "pug": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/svelte-routing": {
@@ -23243,7 +23424,8 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz",
       "integrity": "sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@mapbox/point-geometry": {
       "version": "0.1.0",
@@ -23380,7 +23562,8 @@
       "version": "1.6.22",
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.22.tgz",
       "integrity": "sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@mdx-js/util": {
       "version": "1.6.22",
@@ -23713,7 +23896,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@storybook/addon-measure/-/addon-measure-2.0.0.tgz",
       "integrity": "sha512-ZhdT++cX+L9LwjhGYggvYUUVQH/MGn2rwbrAwCMzA/f2QTFvkjxzX8nDgMxIhaLCDC+gHIxfJG2wrWN0jkBr3g==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@storybook/addon-svelte-csf": {
       "version": "1.1.0",
@@ -26494,6 +26678,12 @@
       "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
       "dev": true
     },
+    "@types/pug": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pug/-/pug-2.0.5.tgz",
+      "integrity": "sha512-LOnASQoeNZMkzexRuyqcBBDZ6rS+rQxUMkmj5A0PkhhiSZivLIuz6Hxyr1mkGoEZEkk66faROmpMi4fFkrKsBA==",
+      "dev": true
+    },
     "@types/qs": {
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
@@ -26541,6 +26731,15 @@
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
       "integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/sass": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@types/sass/-/sass-1.43.0.tgz",
+      "integrity": "sha512-DPSXNJ1rYLo88GyF9tuB4bsYGfpKI1a4+wOQmc+LI1SUoocm9QLRSpz0GxxuyjmJsYFIQo/dDlRSSpIXngff+w==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -26848,7 +27047,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -26913,13 +27113,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ansi-align": {
       "version": "3.0.1",
@@ -27792,6 +27994,12 @@
           "dev": true
         }
       }
+    },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "dev": true
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -29133,6 +29341,12 @@
         "repeat-string": "^1.5.4"
       }
     },
+    "detect-indent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
+      "dev": true
+    },
     "detect-port": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.3.0.tgz",
@@ -29642,6 +29856,12 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.6.2.tgz",
       "integrity": "sha512-n0XTVMGps+Deyr38jtqKPR5F5hb9owYeRQcKJW39eFvzUk/u/9Ww315werRzbiNMnHCUw/YHDPBphTlEnzdi+A==",
+      "dev": true
+    },
+    "es6-promise": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+      "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=",
       "dev": true
     },
     "es6-shim": {
@@ -32727,7 +32947,8 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.3.tgz",
       "integrity": "sha512-jtQ6VyT7rMT5tPV0g2EJakEnXLiPksnvlYtwQsVVZ611JsWGN8bQ1tVSDX4s6JllfEH6wmsYxNjTUAMrPmNA8w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "md5.js": {
       "version": "1.3.5",
@@ -32945,6 +33166,12 @@
       "requires": {
         "dom-walk": "^0.1.0"
       }
+    },
+    "min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true
     },
     "minimalistic-assert": {
       "version": "1.0.1",
@@ -34584,7 +34811,8 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.5.0.tgz",
       "integrity": "sha512-BuzrlrM0ylg7coPkXOrRqlf2BgHLw5L44sybbr9Lg4xy7w9e5N7fGYbojOO0s8J0nvrM3PERN2rVFkvSa24lnQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "react-dev-utils": {
       "version": "11.0.4",
@@ -35417,6 +35645,29 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
+    "sander": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/sander/-/sander-0.5.1.tgz",
+      "integrity": "sha1-dB4kXiMfB8r7b98PEzrfohalAq0=",
+      "dev": true,
+      "requires": {
+        "es6-promise": "^3.1.2",
+        "graceful-fs": "^4.1.3",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.2"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        }
+      }
+    },
     "sane": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/sane/-/sane-4.1.0.tgz",
@@ -35568,6 +35819,15 @@
             "repeat-string": "^1.6.1"
           }
         }
+      }
+    },
+    "sass": {
+      "version": "1.43.4",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.43.4.tgz",
+      "integrity": "sha512-/ptG7KE9lxpGSYiXn7Ar+lKOv37xfWsZRtFYal2QHNigyVQDx685VFT/h7ejVr+R8w7H4tmUgtulsKl5YpveOg==",
+      "dev": true,
+      "requires": {
+        "chokidar": ">=3.0.0 <4.0.0"
       }
     },
     "scheduler": {
@@ -36056,6 +36316,18 @@
         }
       }
     },
+    "sorcery": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/sorcery/-/sorcery-0.10.0.tgz",
+      "integrity": "sha1-iukK19fLBfxZ8asMY3hF1cFaUrc=",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "^0.2.5",
+        "minimist": "^1.2.0",
+        "sander": "^0.5.0",
+        "sourcemap-codec": "^1.3.0"
+      }
+    },
     "sort-keys": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
@@ -36540,6 +36812,15 @@
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
+    "strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "requires": {
+        "min-indent": "^1.0.0"
+      }
+    },
     "strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -36601,8 +36882,7 @@
     "svelte": {
       "version": "3.44.1",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.44.1.tgz",
-      "integrity": "sha512-4DrCEJoBvdR689efHNSxIQn2pnFwB7E7j2yLEJtHE/P8hxwZWIphCtJ8are7bjl/iVMlcEf5uh5pJ68IwR09vQ==",
-      "dev": true
+      "integrity": "sha512-4DrCEJoBvdR689efHNSxIQn2pnFwB7E7j2yLEJtHE/P8hxwZWIphCtJ8are7bjl/iVMlcEf5uh5pJ68IwR09vQ=="
     },
     "svelte-dev-helper": {
       "version": "1.1.9",
@@ -36614,7 +36894,8 @@
       "version": "0.14.7",
       "resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.14.7.tgz",
       "integrity": "sha512-pDrzgcWSoMaK6AJkBWkmgIsecW0GChxYZSZieIYfCP0v2oPyx2CYU/zm7TBIcjLVUPP714WxmViE9Thht4etog==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "svelte-loader": {
       "version": "3.1.2",
@@ -36625,6 +36906,20 @@
         "loader-utils": "^2.0.0",
         "svelte-dev-helper": "^1.1.9",
         "svelte-hmr": "^0.14.2"
+      }
+    },
+    "svelte-preprocess": {
+      "version": "4.9.8",
+      "resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.9.8.tgz",
+      "integrity": "sha512-EQS/oRZzMtYdAprppZxY3HcysKh11w54MgA63ybtL+TAZ4hVqYOnhw41JVJjWN9dhPnNjjLzvbZ2tMhTsla1Og==",
+      "dev": true,
+      "requires": {
+        "@types/pug": "^2.0.4",
+        "@types/sass": "^1.16.0",
+        "detect-indent": "^6.0.0",
+        "magic-string": "^0.25.7",
+        "sorcery": "^0.10.0",
+        "strip-indent": "^3.0.0"
       }
     },
     "svelte-routing": {
@@ -37470,7 +37765,8 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.1.tgz",
       "integrity": "sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "use-latest": {
       "version": "1.2.0",
@@ -38338,7 +38634,8 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/webpack-filter-warnings-plugin/-/webpack-filter-warnings-plugin-1.2.1.tgz",
       "integrity": "sha512-Ez6ytc9IseDMLPo0qCuNNYzgtUl8NovOqjIq4uAU8LTD4uoa1w1KpZyyzFtLTEMZpkkOkLfL9eN+KGYdk1Qtwg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "webpack-hot-middleware": {
       "version": "2.25.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@ons/design-system": "^42.1.0",
         "d3-scale": "^3.2.3",
         "d3-shape": "^2.0.0",
+        "normalize-scss": "^7.0.1",
         "simple-statistics": "^7.4.0",
         "svelte-routing": "^1.6.0"
       },
@@ -30,8 +31,8 @@
         "layercake": "^4.0.3",
         "mapbox-gl": "1.13.0",
         "rollup": "^2.3.4",
-        "rollup-plugin-css-only": "^3.1.0",
         "rollup-plugin-livereload": "^2.0.0",
+        "rollup-plugin-scss": "^3.0.0",
         "rollup-plugin-svelte": "^7.0.0",
         "rollup-plugin-terser": "^7.0.0",
         "sass": "^1.43.4",
@@ -15104,6 +15105,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/normalize-scss": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-scss/-/normalize-scss-7.0.1.tgz",
+      "integrity": "sha512-qj16bWnYs+9/ac29IgGjySg4R5qQTp1lXfm7ApFOZNVBYFY8RZ3f8+XQNDDLHeDtI3Ba7Jj4+LuPgz9v/fne2A=="
+    },
     "node_modules/normalize-url": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
@@ -17595,34 +17601,6 @@
         "fsevents": "~2.1.2"
       }
     },
-    "node_modules/rollup-plugin-css-only": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-css-only/-/rollup-plugin-css-only-3.1.0.tgz",
-      "integrity": "sha512-TYMOE5uoD76vpj+RTkQLzC9cQtbnJNktHPB507FzRWBVaofg7KhIqq1kGbcVOadARSozWF883Ho9KpSPKH8gqA==",
-      "dev": true,
-      "dependencies": {
-        "@rollup/pluginutils": "4"
-      },
-      "engines": {
-        "node": ">=10.12.0"
-      },
-      "peerDependencies": {
-        "rollup": "1 || 2"
-      }
-    },
-    "node_modules/rollup-plugin-css-only/node_modules/@rollup/pluginutils": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.1.tgz",
-      "integrity": "sha512-clDjivHqWGXi7u+0d2r2sBi4Ie6VLEAzWMIkvJLnDmxoOhBYOTfzGbOQBA32THHm11/LiJbd01tJUpJsbshSWQ==",
-      "dev": true,
-      "dependencies": {
-        "estree-walker": "^2.0.1",
-        "picomatch": "^2.2.2"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
     "node_modules/rollup-plugin-livereload": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-livereload/-/rollup-plugin-livereload-2.0.0.tgz",
@@ -17633,6 +17611,15 @@
       },
       "engines": {
         "node": ">=8.3"
+      }
+    },
+    "node_modules/rollup-plugin-scss": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-scss/-/rollup-plugin-scss-3.0.0.tgz",
+      "integrity": "sha512-UldNaNHEon2a5IusHvj/Nnwc7q13YDvbFxz5pfNbHBNStxGoUNyM+0XwAA/UafJ1u8XRPGdBMrhWFthrrGZdWQ==",
+      "dev": true,
+      "dependencies": {
+        "rollup-pluginutils": "^2.3.3"
       }
     },
     "node_modules/rollup-plugin-svelte": {
@@ -33572,6 +33559,11 @@
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
       "dev": true
     },
+    "normalize-scss": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-scss/-/normalize-scss-7.0.1.tgz",
+      "integrity": "sha512-qj16bWnYs+9/ac29IgGjySg4R5qQTp1lXfm7ApFOZNVBYFY8RZ3f8+XQNDDLHeDtI3Ba7Jj4+LuPgz9v/fne2A=="
+    },
     "normalize-url": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
@@ -35516,27 +35508,6 @@
         "fsevents": "~2.1.2"
       }
     },
-    "rollup-plugin-css-only": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-css-only/-/rollup-plugin-css-only-3.1.0.tgz",
-      "integrity": "sha512-TYMOE5uoD76vpj+RTkQLzC9cQtbnJNktHPB507FzRWBVaofg7KhIqq1kGbcVOadARSozWF883Ho9KpSPKH8gqA==",
-      "dev": true,
-      "requires": {
-        "@rollup/pluginutils": "4"
-      },
-      "dependencies": {
-        "@rollup/pluginutils": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.1.tgz",
-          "integrity": "sha512-clDjivHqWGXi7u+0d2r2sBi4Ie6VLEAzWMIkvJLnDmxoOhBYOTfzGbOQBA32THHm11/LiJbd01tJUpJsbshSWQ==",
-          "dev": true,
-          "requires": {
-            "estree-walker": "^2.0.1",
-            "picomatch": "^2.2.2"
-          }
-        }
-      }
-    },
     "rollup-plugin-livereload": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-livereload/-/rollup-plugin-livereload-2.0.0.tgz",
@@ -35544,6 +35515,15 @@
       "dev": true,
       "requires": {
         "livereload": "^0.9.1"
+      }
+    },
+    "rollup-plugin-scss": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-scss/-/rollup-plugin-scss-3.0.0.tgz",
+      "integrity": "sha512-UldNaNHEon2a5IusHvj/Nnwc7q13YDvbFxz5pfNbHBNStxGoUNyM+0XwAA/UafJ1u8XRPGdBMrhWFthrrGZdWQ==",
+      "dev": true,
+      "requires": {
+        "rollup-pluginutils": "^2.3.3"
       }
     },
     "rollup-plugin-svelte": {

--- a/package.json
+++ b/package.json
@@ -30,9 +30,11 @@
     "rollup-plugin-livereload": "^2.0.0",
     "rollup-plugin-svelte": "^7.0.0",
     "rollup-plugin-terser": "^7.0.0",
+    "sass": "^1.43.4",
     "sirv-cli": "^1.0.0",
     "svelte": "^3.44.1",
     "svelte-loader": "^3.1.2",
+    "svelte-preprocess": "^4.9.8",
     "topojson-client": "^3.1.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "layercake": "^4.0.3",
     "mapbox-gl": "1.13.0",
     "rollup": "^2.3.4",
-    "rollup-plugin-css-only": "^3.1.0",
     "rollup-plugin-livereload": "^2.0.0",
+    "rollup-plugin-scss": "^3.0.0",
     "rollup-plugin-svelte": "^7.0.0",
     "rollup-plugin-terser": "^7.0.0",
     "sass": "^1.43.4",
@@ -41,6 +41,7 @@
     "@ons/design-system": "^42.1.0",
     "d3-scale": "^3.2.3",
     "d3-shape": "^2.0.0",
+    "normalize-scss": "^7.0.1",
     "simple-statistics": "^7.4.0",
     "svelte-routing": "^1.6.0"
   }

--- a/public/index.html
+++ b/public/index.html
@@ -17,6 +17,7 @@
 	<link rel='stylesheet' href='./global.css'>
 	<link rel='stylesheet' href='./build/bundle.css'>
 
+	<script src="./build/ons-design-system.js"></script>
 	<script defer src='./build/bundle.js'></script>
 </head>
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,9 +1,11 @@
 import svelte from 'rollup-plugin-svelte';
+import sveltePreprocess from 'svelte-preprocess';
 import commonjs from '@rollup/plugin-commonjs';
 import resolve from '@rollup/plugin-node-resolve';
 import livereload from 'rollup-plugin-livereload';
 import { terser } from 'rollup-plugin-terser';
-import css from 'rollup-plugin-css-only';
+import scss from 'rollup-plugin-scss'
+
 
 const production = !process.env.ROLLUP_WATCH;
 
@@ -45,6 +47,9 @@ export default [
 	},
 	plugins: [
 		svelte({
+			preprocess: sveltePreprocess({
+				scss: { includePaths: ['/node_modules/@ons/design-system', './node_modules/normalize-scss/sass'] },
+			}),
 			compilerOptions: {
 				hydratable: true,
 				// enable run-time checks when not in production
@@ -53,7 +58,7 @@ export default [
 		}),
 		// we'll extract any component CSS out into
 		// a separate file - better for performance
-		css({ output: 'bundle.css' }),
+		scss({ output: 'public/build/bundle.css' }),
 
 		// If you have external dependencies installed from
 		// npm, you'll most likely need these plugins. In

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -28,7 +28,14 @@ function serve() {
 	};
 }
 
-export default {
+export default [
+  {
+    input: "./node_modules/@ons/design-system/scripts/main.js",
+    output: {
+      file: "public/build/ons-design-system.js",
+    },
+  },
+  {
 	input: 'src/main.js',
 	output: {
 		sourcemap: true,
@@ -74,4 +81,5 @@ export default {
 	watch: {
 		clearScreen: false
 	}
-};
+  }
+];

--- a/src/routes/DesignSystemApp.svelte
+++ b/src/routes/DesignSystemApp.svelte
@@ -1,5 +1,4 @@
 <script>
-    import "../../node_modules/@ons/design-system/css/census.css"
     import ONSCensusApp from "../ui/ons/ONSCensusApp.svelte"
     import ONSAccordion from "../ui/ons/ONSAccordion.svelte";
     import ONSBacklink from "../ui/ons/ONSBacklink.svelte";
@@ -17,6 +16,13 @@
 
     let hint = "This is a hint"
 </script>
+
+<style lang="scss" global>
+    /* @import '../../node_modules/@ons/design-system/scss/main.scss';
+     * XXX: This fails for many reasons. Sticking to global CSS for now with only variables exposed via SCSS. */
+    @import '../../node_modules/@ons/design-system/css/census';
+    @import '../../node_modules/@ons/design-system/scss/vars/_index.scss';
+</style>
 
 <ONSCensusApp>
 

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,0 +1,5 @@
+import sveltePreprocess from 'svelte-preprocess';
+
+export default {
+    preprocess: sveltePreprocess()
+};


### PR DESCRIPTION
This makes use of Design System JS bundle, and exposes SCSS variables (while still relying on the whole CSS bundle).

Worth noting:
- We should probably reorganise file structure (both `ui/ons/components` and `public/build`) for clarity and to align with what SvelteKit uses by default but let's leave that until all code is integrated (or next sprint).
- "Our" DS components should ideally make use of their per-component JS files, but they seem to be buggy.
- The DS components should also ideally make use of their accompanied SCSS files, but ONS Design System uses a depracated Sass version (`node-sass`) and makes use of the glob `**/*` pattern (via `node-sass-glob-importer`) that `dart-sass` does not support. I'm checking with DS team whether they're going to move to Dart Sass, or whether we need to step back in order to process their files. Either way the temporary workarounds should be enough for now.