### PR TITLE
Feature/design system text area - ticket#89

### DIFF
--- a/src/routes/DesignSystemApp.svelte
+++ b/src/routes/DesignSystemApp.svelte
@@ -186,11 +186,11 @@
   >
     <ONSTextArea
       id="text-area"
+      labelText="Text area"
       hint="this is a hint for text area"
       onChange={(textAreaValue) =>
         console.log("Displays what user is typing every time they click outside of the text area box: ", textAreaValue)}
-      >Text area</ONSTextArea
-    >
+    />
   </DesignSystemPanel>
 
   <DesignSystemPanel

--- a/src/routes/DesignSystemApp.svelte
+++ b/src/routes/DesignSystemApp.svelte
@@ -182,12 +182,45 @@
 
   <DesignSystemPanel
     title="Text area"
-    code={`<ONSTextArea id="text-area" hint="this is a hint for text area">Text area</ONSTextArea>`}
-  >
-    <ONSTextArea
-      id="text-area"
+    code={`<ONSTextArea
+      id="text-area-1"
       labelText="Text area"
       hint="this is a hint for text area"
+      placeholderText="enter your placeholder text..."
+      onChange={(textAreaValue) =>
+        console.log("Displays what user is typing every time they click outside of the text area box: ", textAreaValue)}
+      onInput={(textAreaValue) => console.log("Text area user value: ", textAreaValue)}
+    />`}
+  >
+    <ONSTextArea
+      id="text-area-1"
+      labelText="Text area"
+      hint="this is a hint for text area"
+      placeholderText="enter your placeholder text..."
+      onChange={(textAreaValue) =>
+        console.log("Displays what user is typing every time they click outside of the text area box: ", textAreaValue)}
+      onInput={(textAreaValue) => console.log("Text area user value: ", textAreaValue)}
+    />
+  </DesignSystemPanel>
+
+  <DesignSystemPanel
+    title="Text area - error message"
+    code={`<ONSTextArea
+      id="text-area-2"
+      labelText="Text area"
+      hint="this is a hint for text area"
+      renderError
+      placeholderText="enter your placeholder text..."
+      onChange={(textAreaValue) =>
+        console.log("Displays what user is typing every time they click outside of the text area box: ", textAreaValue)}
+      onInput={(textAreaValue) => console.log("Text area user value: ", textAreaValue)}
+    />`}
+  >
+    <ONSTextArea
+      id="text-area-2"
+      labelText="Text area"
+      hint="this is a hint for text area"
+      renderError
       placeholderText="enter your placeholder text..."
       onChange={(textAreaValue) =>
         console.log("Displays what user is typing every time they click outside of the text area box: ", textAreaValue)}

--- a/src/routes/DesignSystemApp.svelte
+++ b/src/routes/DesignSystemApp.svelte
@@ -188,6 +188,7 @@
       id="text-area"
       labelText="Text area"
       hint="this is a hint for text area"
+      placeholderText="enter your placeholder text..."
       onChange={(textAreaValue) =>
         console.log("Displays what user is typing every time they click outside of the text area box: ", textAreaValue)}
       onInput={(textAreaValue) => console.log("Text area user value: ", textAreaValue)}

--- a/src/routes/DesignSystemApp.svelte
+++ b/src/routes/DesignSystemApp.svelte
@@ -184,7 +184,13 @@
     title="Text area"
     code={`<ONSTextArea id="text-area" hint="this is a hint for text area">Text area</ONSTextArea>`}
   >
-    <ONSTextArea id="text-area" hint="this is a hint for text area">Text area</ONSTextArea>
+    <ONSTextArea
+      id="text-area"
+      hint="this is a hint for text area"
+      onChange={(textAreaValue) =>
+        console.log("Displays what user is typing every time they click outside of the text area box: ", textAreaValue)}
+      >Text area</ONSTextArea
+    >
   </DesignSystemPanel>
 
   <DesignSystemPanel

--- a/src/routes/DesignSystemApp.svelte
+++ b/src/routes/DesignSystemApp.svelte
@@ -190,6 +190,7 @@
       hint="this is a hint for text area"
       onChange={(textAreaValue) =>
         console.log("Displays what user is typing every time they click outside of the text area box: ", textAreaValue)}
+      onInput={(textAreaValue) => console.log("Text area user value: ", textAreaValue)}
     />
   </DesignSystemPanel>
 

--- a/src/ui/ons/ONSTextArea.svelte
+++ b/src/ui/ons/ONSTextArea.svelte
@@ -1,28 +1,32 @@
 <script>
-  export let id, onChange, textAreaValue, onInput, placeholderText;
+  import ONSError from "./partials/ONSError.svelte";
+  export let id, onChange, textAreaValue, onInput, placeholderText, renderError;
   export let name = "";
   export let rows = 8;
   export let hint = "";
   export let labelText = "";
+  export let errorText = "Custom error message";
 </script>
 
-<div class="ons-field">
-  <label class="ons-label  {hint ? 'ons-label--with-description' : ''}" for={id}>
-    {labelText}
-  </label>
-  {#if hint}
-    <span id="{id}-description-hint" class="ons-label__description  ons-input--with-description">
-      {hint}
-    </span>
-  {/if}
-  <textarea
-    bind:value={textAreaValue}
-    {id}
-    placeholder={placeholderText}
-    class="ons-input ons-input--textarea"
-    name={name ? name : id}
-    {rows}
-    on:change={() => onChange(textAreaValue)}
-    on:input={() => onInput(textAreaValue)}
-  />
-</div>
+<ONSError {errorText} {id} {renderError}>
+  <div class="ons-field">
+    <label class="ons-label  {hint ? 'ons-label--with-description' : ''}" for={id}>
+      {labelText}
+    </label>
+    {#if hint}
+      <span id="{id}-description-hint" class="ons-label__description  ons-input--with-description">
+        {hint}
+      </span>
+    {/if}
+    <textarea
+      bind:value={textAreaValue}
+      {id}
+      placeholder={placeholderText}
+      class="ons-input ons-input--textarea {renderError ? 'ons-input--error' : ''}"
+      name={name ? name : id}
+      {rows}
+      on:change={() => onChange(textAreaValue)}
+      on:input={() => onInput(textAreaValue)}
+    />
+  </div>
+</ONSError>

--- a/src/ui/ons/ONSTextArea.svelte
+++ b/src/ui/ons/ONSTextArea.svelte
@@ -7,7 +7,7 @@
 </script>
 
 <div class="ons-field">
-  <label class="ons-label  ons-label--with-description " for={id}>
+  <label class="ons-label  {hint ? 'ons-label--with-description' : ''}" for={id}>
     {labelText}
   </label>
   {#if hint}

--- a/src/ui/ons/ONSTextArea.svelte
+++ b/src/ui/ons/ONSTextArea.svelte
@@ -1,8 +1,7 @@
 <script>
-  export let id;
+  export let id, onChange, textAreaValue;
   export let name = "";
   export let rows = 8;
-  export let value = "";
   export let hint = "";
 </script>
 
@@ -15,5 +14,12 @@
       {hint}
     </span>
   {/if}
-  <textarea {id} class="ons-input ons-input--textarea   " name={name ? name : id} {rows} />
+  <textarea
+    bind:value={textAreaValue}
+    {id}
+    class="ons-input ons-input--textarea"
+    name={name ? name : id}
+    {rows}
+    on:change={() => onChange(textAreaValue)}
+  />
 </div>

--- a/src/ui/ons/ONSTextArea.svelte
+++ b/src/ui/ons/ONSTextArea.svelte
@@ -1,5 +1,5 @@
 <script>
-  export let id, onChange, textAreaValue;
+  export let id, onChange, textAreaValue, onInput;
   export let name = "";
   export let rows = 8;
   export let hint = "";
@@ -22,5 +22,6 @@
     name={name ? name : id}
     {rows}
     on:change={() => onChange(textAreaValue)}
+    on:input={() => onInput(textAreaValue)}
   />
 </div>

--- a/src/ui/ons/ONSTextArea.svelte
+++ b/src/ui/ons/ONSTextArea.svelte
@@ -1,5 +1,5 @@
 <script>
-  export let id, onChange, textAreaValue, onInput;
+  export let id, onChange, textAreaValue, onInput, placeholderText;
   export let name = "";
   export let rows = 8;
   export let hint = "";
@@ -18,6 +18,7 @@
   <textarea
     bind:value={textAreaValue}
     {id}
+    placeholder={placeholderText}
     class="ons-input ons-input--textarea"
     name={name ? name : id}
     {rows}

--- a/src/ui/ons/ONSTextArea.svelte
+++ b/src/ui/ons/ONSTextArea.svelte
@@ -3,11 +3,12 @@
   export let name = "";
   export let rows = 8;
   export let hint = "";
+  export let labelText = "";
 </script>
 
 <div class="ons-field">
   <label class="ons-label  ons-label--with-description " for={id}>
-    <slot />
+    {labelText}
   </label>
   {#if hint}
     <span id="{id}-description-hint" class="ons-label__description  ons-input--with-description">


### PR DESCRIPTION
I have updated the `<ONSTextArea />` component following the `<ONSTextField />` example and the associated trello ticket#89. 

**Differences :**  

1. The placeholder is passed down as a prop and I believe it is not accessible like the input one. I couldn't find an example of a text area with a placeholder text on the ONS DS page and neither an `ons class` that refers to a `text-area-placeholder` in the `main.css` file of the DS.
2. On the design system page I didn't add a `<p>` tag element to render the user input like I did on the `<ONSTextField />` component so let me know if we need that.
3. On the trello ticket#89 there was a check item for adding a `type` attribute as a prop on the `<ONSTextArea />`component ; I suspect that this is not actually applicable for a `<textarea>`element, right ?  