### PR TITLE
Feature/add change area overlay

### DIFF
--- a/src/routes/data/[categoryId]/locations/[locationId].svelte
+++ b/src/routes/data/[categoryId]/locations/[locationId].svelte
@@ -20,9 +20,18 @@
   import InteractiveLayer from "./../../../../ui/map/InteractiveLayer.svelte";
   import DataLayer from "./../../../../ui/map/DataLayer.svelte";
   import { appIsInitialised } from "./../../../../model/appstate";
+  import Header from "../../../../ui/Header.svelte";
+  import ExploreByAreaComponent from "../../../../ui/ExploreByAreaComponent.svelte";
 
   export let categoryId;
   export let locationId;
+
+  let autosuggestData = "https://raw.githubusercontent.com/ONSdigital/census-atlas/master/src/data/ladList.json";
+  let showChangeAreaHeader = false;
+
+  const toggleChangeAreaHeader = () => {
+    showChangeAreaHeader = !showChangeAreaHeader;
+  };
 
   // temporary line to load some data
   $: appIsInitialised, $appIsInitialised && fetchCensusData("QS119EW005", null);
@@ -35,7 +44,14 @@
 
 <BasePage>
   <span slot="header">
-    <DataHeader tableName={categoryId} location={locationId} />
+    {#if showChangeAreaHeader}
+      <Header showBackLink serviceTitle="Choose an area"
+        ><ExploreByAreaComponent {autosuggestData} header on:click={toggleChangeAreaHeader} /></Header
+      >
+    {:else}
+      <DataHeader tableName={categoryId} location={locationId} on:click={toggleChangeAreaHeader} />
+    {/if}
+
     <CategorySelector />
   </span>
 

--- a/src/routes/locations/[locationId].svelte
+++ b/src/routes/locations/[locationId].svelte
@@ -6,6 +6,15 @@
   import DataHeader from "./../../ui/DataHeader.svelte";
   import ONSShare from "./../../ui/ons/ONSShare.svelte";
   import Feedback from "./../../ui/Feedback.svelte";
+  import Header from "../../ui/Header.svelte";
+  import ExploreByAreaComponent from "../../ui/ExploreByAreaComponent.svelte";
+
+  let autosuggestData = "https://raw.githubusercontent.com/ONSdigital/census-atlas/master/src/data/ladList.json";
+  let showChangeAreaHeader = false;
+
+  const toggleChangeAreaHeader = () => {
+    showChangeAreaHeader = !showChangeAreaHeader;
+  };
 
   import ONSPhaseBanner from "./../../ui/ons/ONSPhaseBanner.svelte";
 
@@ -26,7 +35,13 @@
 
 <BasePage>
   <span slot="header">
-    <DataHeader location={locationId} />
+    {#if showChangeAreaHeader}
+      <Header showBackLink serviceTitle="Choose an area"
+        ><ExploreByAreaComponent {autosuggestData} header on:click={toggleChangeAreaHeader} /></Header
+      >
+    {:else}
+      <DataHeader location={locationId} on:click={toggleChangeAreaHeader} />
+    {/if}
   </span>
 
   <span slot="map">

--- a/src/ui/DataHeader.svelte
+++ b/src/ui/DataHeader.svelte
@@ -22,12 +22,12 @@
       {#if location}
         <div class="ons-grid--flex ons-grid--between">
           <h2 class="ons-header__title" id="header-data-2__location">In {location}</h2>
-          <a href="0#">Change</a>
+          <a href="0#" on:click>Change</a>
         </div>
       {:else}
         <div class="ons-grid--flex ons-grid--between ons-grid--vertical-center">
           <h3 class="ons-header__desc">In England & Wales</h3>
-          <a href="0#">Change</a>
+          <a href="0#" on:click>Change</a>
         </div>
       {/if}
     </div>

--- a/src/ui/ExploreByAreaComponent.svelte
+++ b/src/ui/ExploreByAreaComponent.svelte
@@ -15,7 +15,7 @@
   <div class="ons-field">
     <p><slot /></p>
     <ONSAutosuggest {labelText} {header} {id} {hint} {autosuggestData} bind:autosuggestValue={userInputValue} />
-    <button type="submit" class="ons-btn ons-u-mt-s ons-btn--small">
+    <button on:click type="submit" class="ons-btn ons-u-mt-s ons-btn--small">
       <span class="ons-btn__inner"> {buttonText}</span>
     </button>
   </div>


### PR DESCRIPTION
### **What**

I have added the logic to toggle the header on [Explore by Location (Walsall)](http://localhost:3000/locations/Walsall) and [Explore by Category & Location](http://localhost:3000/data/General%20health/locations/England%20&%20Wales) screens when a user wants to search for a different location.

I haven't added the styling, I leave this with you @designorant because when I am trying to use a position on the header everything moves around the page...

**Note:** The js does not load on the `<ONSAutosuggest/>` component on an `on:click` event because at the moment we can only load the ons DS js at a page level not at a component level and we hope that this will go away once the  [issue](https://github.com/ONSdigital/design-system/issues/1761) is fixed by the design system team.

![Screenshot 2021-11-29 at 14 50 13](https://user-images.githubusercontent.com/70764326/143890572-0beaf36d-7f10-4b0e-8638-5f89bc14f7d7.png)


![Screenshot 2021-11-29 at 14 50 21](https://user-images.githubusercontent.com/70764326/143890533-54cd7596-379e-46ea-9aae-92b98c7b3e68.png)


