### PR TITLE
Feature/data driven home screen - #ticket115 

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -70,3 +70,15 @@ export default {
     },
   },
 };
+
+export const suggestions = [
+  { text: "Where are the highest levels of home ownership?", url: "/housing/tenure-households/owned" },
+  {
+    text: "Where do people travel the furthest to get to work?",
+    url: "/travel-to-work/distance-travelled-to-work/60km-and-over",
+  },
+  {
+    text: "Where are the highest rates of unemployment?",
+    url: "/employment/economic-activity/economically-active/unemployed",
+  },
+];

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -13,8 +13,7 @@
   import ONSEmailIcon from "./../ui/ons/svg/ONSEmailIcon.svelte";
   import Map from "./../ui/map/Map.svelte";
   import Header from "../ui/Header.svelte";
-  import {suggestions} from "../config.js"
-  
+  import { suggestions } from "../config.js";
 
   let autosuggestData = "https://raw.githubusercontent.com/ONSdigital/census-atlas/master/src/data/ladList.json";
   let englandWalesBounds = [2.08, 55.68, -6.59, 48.53];
@@ -26,7 +25,7 @@
   <script defer src="https://cdn.ons.gov.uk/sdc/design-system/44.1.2/scripts/main.js"></script>
 </svelte:head>
 
-<BasePage>
+<BasePage mobileMap={false}>
   <span slot="header">
     <Header
       serviceTitle="Explore Census"
@@ -47,7 +46,7 @@
     </footer>
   </span>
 
-  <ExploreByTopic url="/categories" {suggestions}/>
+  <ExploreByTopic url="/categories" {suggestions} />
   <hr class="component-margin--2" />
   <ExploreByAreaComponent {autosuggestData}
     >Search for an area to find out how it compares to others</ExploreByAreaComponent

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -12,8 +12,10 @@
   import ONSTwitterIcon from "./../ui/ons/svg/ONSTwitterIcon.svelte";
   import ONSLinkedinIcon from "./../ui/ons/svg/ONSLinkedinIcon.svelte";
   import ONSEmailIcon from "./../ui/ons/svg/ONSEmailIcon.svelte";
+  import Map from "./../ui/map/Map.svelte";
 
   let autosuggestData = "https://raw.githubusercontent.com/ONSdigital/census-atlas/master/src/data/ladList.json";
+  let bounds = [2.08, 55.68, -6.59, 48.53];
 </script>
 
 <svelte:head>
@@ -28,6 +30,10 @@
       serviceTitle="Explore Census"
       description="Here’s a place where we tell users what the Census Atlas is and what it can do for them."
     />
+  </span>
+
+  <span slot="map">
+    <Map {bounds} />
   </span>
 
   <span slot="footer">

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -13,9 +13,11 @@
   import ONSEmailIcon from "./../ui/ons/svg/ONSEmailIcon.svelte";
   import Map from "./../ui/map/Map.svelte";
   import Header from "../ui/Header.svelte";
+  import {suggestions} from "../config.js"
+  
 
   let autosuggestData = "https://raw.githubusercontent.com/ONSdigital/census-atlas/master/src/data/ladList.json";
-  let bounds = [2.08, 55.68, -6.59, 48.53];
+  let englandWalesBounds = [2.08, 55.68, -6.59, 48.53];
 </script>
 
 <svelte:head>
@@ -33,7 +35,7 @@
   </span>
 
   <span slot="map">
-    <Map {bounds} />
+    <Map bounds={englandWalesBounds} />
   </span>
 
   <span slot="footer">
@@ -45,7 +47,7 @@
     </footer>
   </span>
 
-  <ExploreByTopic url="/categories" />
+  <ExploreByTopic url="/categories" {suggestions}/>
   <hr class="component-margin--2" />
   <ExploreByAreaComponent {autosuggestData}
     >Search for an area to find out how it compares to others</ExploreByAreaComponent

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -3,7 +3,6 @@
 
   import ExploreByTopic from "./../ui/ExploreByTopic.svelte";
   import ExploreByAreaComponent from "./../ui/ExploreByAreaComponent.svelte";
-  import ONSExternalHeaderWithDescription from "./../ui/ons/ONSExternalHeaderWithDescription.svelte";
   import ONSShare from "./../ui/ons/ONSShare.svelte";
   import Topic from "./../ui/Topic.svelte";
   import Feedback from "./../ui/Feedback.svelte";
@@ -13,6 +12,7 @@
   import ONSLinkedinIcon from "./../ui/ons/svg/ONSLinkedinIcon.svelte";
   import ONSEmailIcon from "./../ui/ons/svg/ONSEmailIcon.svelte";
   import Map from "./../ui/map/Map.svelte";
+  import Header from "../ui/Header.svelte";
 
   let autosuggestData = "https://raw.githubusercontent.com/ONSdigital/census-atlas/master/src/data/ladList.json";
   let bounds = [2.08, 55.68, -6.59, 48.53];
@@ -26,7 +26,7 @@
 
 <BasePage>
   <span slot="header">
-    <ONSExternalHeaderWithDescription
+    <Header
       serviceTitle="Explore Census"
       description="Here’s a place where we tell users what the Census Atlas is and what it can do for them."
     />

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -7,6 +7,11 @@
   import ONSShare from "./../ui/ons/ONSShare.svelte";
   import Topic from "./../ui/Topic.svelte";
   import Feedback from "./../ui/Feedback.svelte";
+  import ONSShareItem from "./../ui/ons/partials/ONSShareItem.svelte";
+  import ONSFacebookIcon from "./../ui/ons/svg/ONSFacebookIcon.svelte";
+  import ONSTwitterIcon from "./../ui/ons/svg/ONSTwitterIcon.svelte";
+  import ONSLinkedinIcon from "./../ui/ons/svg/ONSLinkedinIcon.svelte";
+  import ONSEmailIcon from "./../ui/ons/svg/ONSEmailIcon.svelte";
 
   let autosuggestData = "https://raw.githubusercontent.com/ONSdigital/census-atlas/master/src/data/ladList.json";
 </script>
@@ -40,7 +45,14 @@
     >Search for an area to find out how it compares to others</ExploreByAreaComponent
   >
 
-  <ONSShare url="https://www.google.com/">Share this page</ONSShare>
+  <div class="ons-u-mb-l">
+    <ONSShare title="Share this page" pageURL={location.href} pageTitle={document.title} multiRow>
+      <ONSShareItem facebook shareText="Facebook"><ONSFacebookIcon /></ONSShareItem>
+      <ONSShareItem twitter shareText="Twitter"><ONSTwitterIcon /></ONSShareItem>
+      <ONSShareItem linkedin shareText="Linkedin"><ONSLinkedinIcon /></ONSShareItem>
+      <ONSShareItem email shareText="Email"><ONSEmailIcon /></ONSShareItem>
+    </ONSShare>
+  </div>
 
   <Topic topicList={[{ title: "Get Census datasests", href: "#" }]} cardTitle="Need something specific from Census?">
     Explore correlations between two indicators in <a href="#">advanced mode</a>.

--- a/src/ui/BasePage.svelte
+++ b/src/ui/BasePage.svelte
@@ -3,8 +3,13 @@
   import ONSHeaderLogoSmall from "./ons/svg/ONSHeaderLogoSmall.svelte";
   import ONSPhaseBanner from "./ons/ONSPhaseBanner.svelte";
 
-  let hasMap = $$slots.map ? "ons-page--has-map" : "";
+  export let mobileMap = true;
+
+  $: innerWidth = 0;
+  let hasMap = $$slots.map && mobileMap ? "ons-page--has-map" : "";
 </script>
+
+<svelte:window bind:innerWidth />
 
 <div class="ons-page {hasMap}">
   <div class="ons-page__content">
@@ -46,7 +51,7 @@
       <div class="header">
         <slot name="header" />
       </div>
-      {#if $$slots.map}
+      {#if (mobileMap && $$slots.map) || (!mobileMap && innerWidth >= 500)}
         <div class="map">
           <slot name="map" />
         </div>

--- a/src/ui/ExploreByTopic.svelte
+++ b/src/ui/ExploreByTopic.svelte
@@ -1,13 +1,18 @@
 <script>
   import ONSCollapsible from "./ons/ONSCollapsible.svelte";
   export let url;
+  export let suggestions;
 </script>
 
 <div class="component-margin--2">
   <h2>Explore by topic</h2>
   <p>The 2021 Census tells us a lot about how people in England and Wales live and work.</p>
   <p><a href={url}>Choose a data option</a></p>
-  <ONSCollapsible title="Show me suggestions"><p><a href="/data/Health">Health</a></p></ONSCollapsible>
+  <ONSCollapsible title="Show me suggestions">
+    {#each suggestions as suggestion}
+      <p><a href={suggestion.url}>{suggestion.text}</a></p>
+    {/each}
+  </ONSCollapsible>
 </div>
 
 <style>

--- a/src/ui/map/Map.svelte
+++ b/src/ui/map/Map.svelte
@@ -7,7 +7,7 @@
   export let minzoom = 0;
   export let maxzoom = 14;
 
-  export let bounds = [-3.413572832073754, 51.10096449720518, -2.4672865337001895, 51.69137186082315];
+  export let bounds = [6.9617545987138385, 55.87030690924996, -8.456487506271117, 48.843594350172594];
   export let zoom = 6;
 
   let options = {


### PR DESCRIPTION
### **What**

We have updated the Home screen as per the `trello ticket 115`, but what we haven't actually touched is the background image. Not sure what improvements are needed on that. 

According to the wireframes the home screen loads a non data map on desktop view, but not on mobile view so we had to conditionally render the map based on the window width and it looks like in svelte you [ can't have conditional slots](https://github.com/sveltejs/svelte/issues/5604) so to get around this we had to update the `<BasePage />` component.

We have also located the map on England & Wales on first load:

![Screenshot 2021-11-30 at 12 54 31](https://user-images.githubusercontent.com/70764326/144051192-e4a5a2f0-fde7-4551-93ed-c84ad222c21c.png)


