### PR TITLE
Feature/area selected screen

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -199,3 +199,24 @@ export const topicSuggestions = [
     ],
   },
 ];
+
+export function areaSelectedTopicSuggestions(ladName, ladCode){
+  return [
+    {
+      text: `How is ${ladName}'s general health?`,
+      url: `/health/general-health/good-health?location=${ladCode}`,
+    },
+    {
+      text: `How deprived is ${ladName}?`,
+      url: `/population-basics/households-by-deprivation-dimensions/household-is-deprived-in-4-dimensions?location=${ladCode}`,
+    },
+    {
+      text: `How many students live in ${ladName}?`,
+      url: `/employment/economic-activity/economically-inactive?location=${ladCode}`,
+    },
+    {
+      text: `How many people living in ${ladName} are unemployed?`,
+      url: `/employment/economic-activity/economically-active?location=${ladCode}`,
+    },
+  ];
+}

--- a/src/model/geography/geography.js
+++ b/src/model/geography/geography.js
@@ -6,6 +6,7 @@ import config from "./../../config";
 export var ladBoundaries = [];
 export var ladList = [];
 export var ladLookup = {};
+export var reverseLadLookup = {};
 export var lsoaLookup = {};
 
 // WRITABLES
@@ -83,6 +84,7 @@ export async function initialiseGeography(geographyService) {
   let lsoaData = await geographyService.getLsoaData();
 
   ladLookup = buildLadLookup(ladList, lsoaData);
+  reverseLadLookup = buildReverseLadLookup(ladList)
   lsoaLookup = buildLsoaLookup(lsoaData);
 
   loadingGeography.set(false);
@@ -100,6 +102,15 @@ function buildLadLookup(ladList, lsoaData) {
 
   lsoaData.forEach((d) => {
     lookup[d.parent].children.push(d.code);
+  });
+
+  return lookup;
+}
+
+function buildReverseLadLookup(ladList){
+  let lookup = {};
+  ladList.forEach((d) => {
+    lookup[d.name] = d.code;
   });
 
   return lookup;

--- a/src/routes/area/index.svelte
+++ b/src/routes/area/index.svelte
@@ -12,17 +12,41 @@
   import ONSLinkedinIcon from "../../ui/ons/svg/ONSLinkedinIcon.svelte";
   import ONSEmailIcon from "../../ui/ons/svg/ONSEmailIcon.svelte";
   import { page } from "$app/stores";
-  import {getLadName} from "../../model/geography/geography"
+  import { getLadName, updateSelectedGeography } from "../../model/geography/geography";
   import { appIsInitialised } from "../../model/appstate";
 
   const locationId = $page.query.get("location");
-  let locationName
+  let locationName;
+  let topicSuggestions;
 
-  function initialisePage(){
-    locationName = getLadName(locationId)
+  function initialisePage() {
+    updateSelectedGeography(locationId);
+    locationName = getLadName(locationId);
+
   }
-  
-  $: appIsInitialised, $appIsInitialised && initialisePage()
+
+  $: appIsInitialised, $appIsInitialised && initialisePage();
+
+  $: {
+    topicSuggestions = [
+      {
+        text: `How is ${locationName}'s general health?`,
+        url: `/health/general-health/good-health?location=${locationId}`,
+      },
+      {
+        text: `How deprived is ${locationName}?`,
+        url: `/population-basics/households-by-deprivation-dimensions/household-is-deprived-in-4-dimensions?location=${locationId}`,
+      },
+      {
+        text: `How many students live in ${locationName}?`,
+        url: `/employment/economic-activity/economically-inactive?location=${locationId}`,
+      },
+      {
+        text: `How many people living in ${locationName} are unemployed?`,
+        url: `/employment/economic-activity/economically-active?location=${locationId}`,
+      },
+    ];
+  }
 </script>
 
 <svelte:head>
@@ -39,13 +63,13 @@
     <Map maxzoom={14} />
   </span>
 
-  <Topic cardTitle="test">
-    The 2021 Census tells us a lot about the health of people living in England and Wales live and.
-    <a href="#0">Choose a data option from the full list</a> or explore one of these suggestions.
+  <Topic cardTitle="{locationName}'s Census" topicList={topicSuggestions}>
+    The 2021 Census tells us a lot about how people in {locationName} live and work.
+    <a href="/categories?location={locationId}">Choose a data option from the full list</a> or explore one of these topics.
   </Topic>
 
   <div class="ons-u-mb-l">
-    <UseCensusData location={"test"} />
+    <UseCensusData location={locationName} />
   </div>
 
   <div class="ons-u-mb-l">

--- a/src/routes/area/index.svelte
+++ b/src/routes/area/index.svelte
@@ -12,9 +12,13 @@
   import ONSLinkedinIcon from "../../ui/ons/svg/ONSLinkedinIcon.svelte";
   import ONSEmailIcon from "../../ui/ons/svg/ONSEmailIcon.svelte";
   import { page } from "$app/stores";
-  import { getLadName, updateSelectedGeography } from "../../model/geography/geography";
+  import { getLadName, updateSelectedGeography, updateHoveredGeography } from "../../model/geography/geography";
   import { appIsInitialised } from "../../model/appstate";
   import {areaSelectedTopicSuggestions} from "../../config"
+  import config from "../../config";
+  import TileSet from "../../ui/map/TileSet.svelte";
+  import InteractiveLayer from "../../ui/map/InteractiveLayer.svelte";
+  import BoundaryLayer from "../../ui/map/BoundaryLayer.svelte";
 
   const locationId = $page.query.get("location");
   let locationName;
@@ -40,11 +44,69 @@
 
 <BasePage>
   <span slot="header">
-    <DataHeader location={locationName} />
+    <DataHeader location={locationName} {locationId} />
   </span>
 
   <span slot="map">
-    <Map maxzoom={14} />
+    <Map maxzoom={14}>
+      <TileSet
+        id="lad"
+        type="vector"
+        url={config.legacy.ladvector.url}
+        layer={config.legacy.ladvector.layer}
+        promoteId={config.legacy.ladvector.code}
+      >
+        <InteractiveLayer
+          id="lad-interactive-layer"
+          maxzoom={config.ux.map.lsoa_breakpoint}
+          onSelect={(code) => {
+            updateSelectedGeography(code);
+          }}
+          onHover={(code) => {
+            updateHoveredGeography(code);
+          }}
+          filter={config.ux.map.filter}
+        />
+      </TileSet>
+
+      <TileSet
+        id="lsoa"
+        type="vector"
+        url={config.legacy.lsoabounds.url}
+        layer={config.legacy.lsoabounds.layer}
+        promoteId={config.legacy.lsoabounds.code}
+        minzoom={config.ux.map.lsoa_breakpoint}
+        maxzoom={config.ux.map.buildings_breakpoint}
+      >
+        <InteractiveLayer
+          id="lsoa-boundaries"
+          onSelect={(code) => {
+            updateSelectedGeography(code);
+          }}
+          onHover={(code) => {
+            updateHoveredGeography(code);
+          }}
+        />
+      </TileSet>
+      <TileSet
+        id="lsoa-building"
+        type="vector"
+        url={config.legacy.lsoabldg.url}
+        layer={config.legacy.lsoabldg.layer}
+        promoteId={config.legacy.lsoabldg.code}
+        minzoom={config.ux.map.buildings_breakpoint}
+      >
+      </TileSet>
+      <TileSet
+        id="lad-boundaries"
+        type="vector"
+        url={config.legacy.ladvector.url}
+        layer={config.legacy.ladvector.layer}
+        promoteId={config.legacy.ladvector.code}
+      >
+        <BoundaryLayer minzoom={config.ux.map.lsoa_breakpoint} id="lad-boundary-layer" />
+      </TileSet>
+    </Map>
   </span>
 
   <Topic cardTitle="{locationName}'s Census" topicList={topicSuggestions}>

--- a/src/routes/area/index.svelte
+++ b/src/routes/area/index.svelte
@@ -1,0 +1,68 @@
+<script>
+  import BasePage from "../../ui/BasePage.svelte";
+  import Map from "../../ui/map/Map.svelte";
+  import Topic from "../../ui/Topic.svelte";
+  import ONSShare from "../../ui/ons/ONSShare.svelte";
+  import UseCensusData from "../../ui/UseCensusData.svelte";
+  import Feedback from "../../ui/Feedback.svelte";
+  import DataHeader from "../../ui/DataHeader.svelte";
+  import ONSShareItem from "../../ui/ons/partials/ONSShareItem.svelte";
+  import ONSFacebookIcon from "../../ui/ons/svg/ONSFacebookIcon.svelte";
+  import ONSTwitterIcon from "../../ui/ons/svg/ONSTwitterIcon.svelte";
+  import ONSLinkedinIcon from "../../ui/ons/svg/ONSLinkedinIcon.svelte";
+  import ONSEmailIcon from "../../ui/ons/svg/ONSEmailIcon.svelte";
+  import { page } from "$app/stores";
+  import {getLadName} from "../../model/geography/geography"
+  import { appIsInitialised } from "../../model/appstate";
+
+  const locationId = $page.query.get("location");
+  let locationName
+
+  function initialisePage(){
+    locationName = getLadName(locationId)
+  }
+  
+  $: appIsInitialised, $appIsInitialised && initialisePage()
+</script>
+
+<svelte:head>
+  <title>2021 Census Data Atlas</title>
+  <script defer src="https://cdn.ons.gov.uk/sdc/design-system/44.1.2/scripts/main.js"></script>
+</svelte:head>
+
+<BasePage>
+  <span slot="header">
+    <DataHeader location={locationName} />
+  </span>
+
+  <span slot="map">
+    <Map maxzoom={14} />
+  </span>
+
+  <Topic cardTitle="test">
+    The 2021 Census tells us a lot about the health of people living in England and Wales live and.
+    <a href="#0">Choose a data option from the full list</a> or explore one of these suggestions.
+  </Topic>
+
+  <div class="ons-u-mb-l">
+    <UseCensusData location={"test"} />
+  </div>
+
+  <div class="ons-u-mb-l">
+    <ONSShare>
+      <ONSShareItem facebook shareText="Facebook"><ONSFacebookIcon /></ONSShareItem>
+      <ONSShareItem twitter shareText="Twitter"><ONSTwitterIcon /></ONSShareItem>
+      <ONSShareItem linkedin shareText="Linkedin"><ONSLinkedinIcon /></ONSShareItem>
+      <ONSShareItem email shareText="Email"><ONSEmailIcon /></ONSShareItem>
+    </ONSShare>
+  </div>
+
+  <span slot="footer">
+    <footer class="ons-footer">
+      <div class="ons-footer__body ons-page__footer" data-analytics="footer">
+        <div class="ons-container" />
+        <Feedback />
+      </div>
+    </footer>
+  </span>
+</BasePage>

--- a/src/routes/area/index.svelte
+++ b/src/routes/area/index.svelte
@@ -27,7 +27,6 @@
   function initialisePage() {
     updateSelectedGeography(locationId);
     locationName = getLadName(locationId);
-
   }
 
   $: appIsInitialised, $appIsInitialised && initialisePage();

--- a/src/routes/area/index.svelte
+++ b/src/routes/area/index.svelte
@@ -14,6 +14,7 @@
   import { page } from "$app/stores";
   import { getLadName, updateSelectedGeography } from "../../model/geography/geography";
   import { appIsInitialised } from "../../model/appstate";
+  import {areaSelectedTopicSuggestions} from "../../config"
 
   const locationId = $page.query.get("location");
   let locationName;
@@ -28,24 +29,7 @@
   $: appIsInitialised, $appIsInitialised && initialisePage();
 
   $: {
-    topicSuggestions = [
-      {
-        text: `How is ${locationName}'s general health?`,
-        url: `/health/general-health/good-health?location=${locationId}`,
-      },
-      {
-        text: `How deprived is ${locationName}?`,
-        url: `/population-basics/households-by-deprivation-dimensions/household-is-deprived-in-4-dimensions?location=${locationId}`,
-      },
-      {
-        text: `How many students live in ${locationName}?`,
-        url: `/employment/economic-activity/economically-inactive?location=${locationId}`,
-      },
-      {
-        text: `How many people living in ${locationName} are unemployed?`,
-        url: `/employment/economic-activity/economically-active?location=${locationId}`,
-      },
-    ];
+    topicSuggestions = areaSelectedTopicSuggestions(locationName, locationId)
   }
 </script>
 

--- a/src/routes/categories.svelte
+++ b/src/routes/categories.svelte
@@ -6,10 +6,25 @@
   import TopicExplorer from "./../ui/TopicExplorer.svelte";
   import Topic from "../ui/Topic.svelte";
   import Feedback from "./../ui/Feedback.svelte";
+  import { page } from "$app/stores";
+  import { appIsInitialised } from "../model/appstate";
 
-  import { selectedGeography } from "../model/geography/geography";
+  import { getLadName, updateSelectedGeography } from "../model/geography/geography";
 
   let englandWalesBounds = [2.08, 55.68, -6.59, 48.53];
+
+  const locationId = $page.query.get("location")
+  let locationName
+
+  $: appIsInitialised, $appIsInitialised && initialisePage()
+  
+  function initialisePage(){
+    if (locationId){
+    locationName = getLadName(locationId)
+    updateSelectedGeography(locationId)
+    }
+  }
+
 
   $: innerWidth = 0;
 </script>
@@ -25,8 +40,8 @@
     <Header
       showBackLink
       serviceTitle="Choose a data option"
-      description="Choose a category and select an option within it to explore {$selectedGeography.lad
-        ? `${$selectedGeography.lad}'s`
+      description="Choose a category and select an option within it to explore {locationName
+        ? `${locationName}'s`
         : 'Census'} data."
     />
   </span>

--- a/src/routes/categories.svelte
+++ b/src/routes/categories.svelte
@@ -25,7 +25,6 @@
     }
   }
 
-
   $: innerWidth = 0;
 </script>
 
@@ -50,7 +49,7 @@
     <Map bounds={englandWalesBounds} />
   </span>
 
-  <TopicExplorer />
+  <TopicExplorer {locationId}/>
 
   {#if innerWidth >= 500}
     <Topic topicList={[{ text: "Get Census datasests", url: "#0" }]} cardTitle="Need something specific from Census?">

--- a/src/routes/categories.svelte
+++ b/src/routes/categories.svelte
@@ -8,8 +8,11 @@
   import Feedback from "./../ui/Feedback.svelte";
   import { page } from "$app/stores";
   import { appIsInitialised } from "../model/appstate";
-
-  import { getLadName, updateSelectedGeography } from "../model/geography/geography";
+  import config from "../config";
+  import TileSet from "../ui/map/TileSet.svelte";
+  import InteractiveLayer from "../ui/map/InteractiveLayer.svelte";
+  import BoundaryLayer from "../ui/map/BoundaryLayer.svelte";
+  import { getLadName, updateSelectedGeography, updateHoveredGeography } from "../model/geography/geography";
 
   let englandWalesBounds = [2.08, 55.68, -6.59, 48.53];
 
@@ -46,7 +49,65 @@
   </span>
 
   <span slot="map">
-    <Map bounds={englandWalesBounds} />
+    <Map maxzoom={14}>
+      <TileSet
+        id="lad"
+        type="vector"
+        url={config.legacy.ladvector.url}
+        layer={config.legacy.ladvector.layer}
+        promoteId={config.legacy.ladvector.code}
+      >
+        <InteractiveLayer
+          id="lad-interactive-layer"
+          maxzoom={config.ux.map.lsoa_breakpoint}
+          onSelect={(code) => {
+            updateSelectedGeography(code);
+          }}
+          onHover={(code) => {
+            updateHoveredGeography(code);
+          }}
+          filter={config.ux.map.filter}
+        />
+      </TileSet>
+
+      <TileSet
+        id="lsoa"
+        type="vector"
+        url={config.legacy.lsoabounds.url}
+        layer={config.legacy.lsoabounds.layer}
+        promoteId={config.legacy.lsoabounds.code}
+        minzoom={config.ux.map.lsoa_breakpoint}
+        maxzoom={config.ux.map.buildings_breakpoint}
+      >
+        <InteractiveLayer
+          id="lsoa-boundaries"
+          onSelect={(code) => {
+            updateSelectedGeography(code);
+          }}
+          onHover={(code) => {
+            updateHoveredGeography(code);
+          }}
+        />
+      </TileSet>
+      <TileSet
+        id="lsoa-building"
+        type="vector"
+        url={config.legacy.lsoabldg.url}
+        layer={config.legacy.lsoabldg.layer}
+        promoteId={config.legacy.lsoabldg.code}
+        minzoom={config.ux.map.buildings_breakpoint}
+      >
+      </TileSet>
+      <TileSet
+        id="lad-boundaries"
+        type="vector"
+        url={config.legacy.ladvector.url}
+        layer={config.legacy.ladvector.layer}
+        promoteId={config.legacy.ladvector.code}
+      >
+        <BoundaryLayer minzoom={config.ux.map.lsoa_breakpoint} id="lad-boundary-layer" />
+      </TileSet>
+    </Map>
   </span>
 
   <TopicExplorer {locationId}/>

--- a/src/routes/categories/[topicSlug].svelte
+++ b/src/routes/categories/[topicSlug].svelte
@@ -6,9 +6,17 @@
   import TopicExplorer from "./../../ui/TopicExplorer.svelte";
   import Topic from "../../ui/Topic.svelte";
   import Feedback from "./../../ui/Feedback.svelte";
-  import { selectedGeography } from "../../model/geography/geography";
+  import { selectedGeography, getLadName } from "../../model/geography/geography";
   import { page } from "$app/stores";
   let { topicSlug } = $page.params;
+  const locationId = $page.query.get("location")
+  let locationName
+
+  $: {
+    if (locationId){
+    locationName = getLadName(locationId)
+  }
+}
 
   $: innerWidth = 0;
 
@@ -27,8 +35,8 @@
     <Header
       showBackLink
       serviceTitle="Choose a data option"
-      description="Choose a category and select an option within it to explore {$selectedGeography.lad
-        ? `${$selectedGeography.lad}'s`
+      description="Choose a category and select an option within it to explore {locationName
+        ? `${locationName}'s`
         : 'Census'} data."
     />
   </span>

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -15,17 +15,14 @@
   import Header from "../ui/Header.svelte";
   import { indexPageSuggestions } from "../config.js";
   import {reverseLadLookup} from "../model/geography/geography"
-  import {appIsInitialised} from "../model/appstate"
   import { goto } from '$app/navigation';
 
   let autosuggestData = "https://raw.githubusercontent.com/ONSdigital/census-atlas/master/src/data/ladList.json";
   let englandWalesBounds = [2.08, 55.68, -6.59, 48.53];
 
-  $: appIsInitialised, $appIsInitialised && console.log(reverseLadLookup)
-
   function submitFunction(ladInput){
     if (reverseLadLookup[ladInput]){
-      goto(`/categories?location=${reverseLadLookup[ladInput]}`)
+      goto(`/area?location=${reverseLadLookup[ladInput]}`)
     }
   }
 </script>

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -19,6 +19,7 @@
 
   let autosuggestData = "https://raw.githubusercontent.com/ONSdigital/census-atlas/master/src/data/ladList.json";
   let englandWalesBounds = [2.08, 55.68, -6.59, 48.53];
+  let userInputValue;
 
   function submitFunction(ladInput){
     if (reverseLadLookup[ladInput]){
@@ -56,7 +57,7 @@
 
   <ExploreByTopic url="/categories" suggestions={indexPageSuggestions} />
   <hr class="component-margin--2" />
-  <ExploreByAreaComponent {autosuggestData} {submitFunction}
+  <ExploreByAreaComponent {autosuggestData} bind:userInputValue={userInputValue} on:click={() => submitFunction(userInputValue)}
     >Search for an area to find out how it compares to others</ExploreByAreaComponent
   >
 

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -14,9 +14,20 @@
   import Map from "./../ui/map/Map.svelte";
   import Header from "../ui/Header.svelte";
   import { indexPageSuggestions } from "../config.js";
+  import {reverseLadLookup} from "../model/geography/geography"
+  import {appIsInitialised} from "../model/appstate"
+  import { goto } from '$app/navigation';
 
   let autosuggestData = "https://raw.githubusercontent.com/ONSdigital/census-atlas/master/src/data/ladList.json";
   let englandWalesBounds = [2.08, 55.68, -6.59, 48.53];
+
+  $: appIsInitialised, $appIsInitialised && console.log(reverseLadLookup)
+
+  function submitFunction(ladInput){
+    if (reverseLadLookup[ladInput]){
+      goto(`/categories?location=${reverseLadLookup[ladInput]}`)
+    }
+  }
 </script>
 
 <svelte:head>
@@ -48,7 +59,7 @@
 
   <ExploreByTopic url="/categories" suggestions={indexPageSuggestions} />
   <hr class="component-margin--2" />
-  <ExploreByAreaComponent {autosuggestData}
+  <ExploreByAreaComponent {autosuggestData} {submitFunction}
     >Search for an area to find out how it compares to others</ExploreByAreaComponent
   >
 

--- a/src/ui/DataHeader.svelte
+++ b/src/ui/DataHeader.svelte
@@ -1,6 +1,8 @@
 <script>
   import slugify from "slugify";
   export let tableName, location, topicPage;
+  export let locationId;
+  let locationQueryParam = locationId ? `?location=${locationId}` : "";
 </script>
 
 <header class="ons-header ons-header--hero" role="banner">
@@ -20,7 +22,7 @@
           <a href="/categories">Change</a>
         {:else}
           <div class="ons-header__title" id="header-data-2__title">
-            <h2 id="census-atlas-header-2__title"><a href="/categories">Choose a data option</a></h2>
+            <h2 id="census-atlas-header-2__title"><a href="/categories{locationQueryParam}">Choose a data option</a></h2>
           </div>
         {/if}
       </div>

--- a/src/ui/ExploreByAreaComponent.svelte
+++ b/src/ui/ExploreByAreaComponent.svelte
@@ -6,7 +6,6 @@
   export let title = "Explore by area";
   import ONSAutosuggest from "./ons/ONSAutosuggest.svelte";
   export let header = false;
-  export let submitFunction
 </script>
 
 <div class="component-margin--2">
@@ -16,7 +15,7 @@
   <div class="ons-field">
     <p><slot /></p>
     <ONSAutosuggest {labelText} {header} {id} {hint} {autosuggestData} bind:autosuggestValue={userInputValue} />
-    <button type="submit" class="ons-btn ons-u-mt-s ons-btn--small" on:click={() => submitFunction(userInputValue)}>
+    <button on:click type="submit" class="ons-btn ons-u-mt-s ons-btn--small">
       <span class="ons-btn__inner"> {buttonText}</span>
     </button>
   </div>

--- a/src/ui/ExploreByAreaComponent.svelte
+++ b/src/ui/ExploreByAreaComponent.svelte
@@ -6,6 +6,7 @@
   export let title = "Explore by area";
   import ONSAutosuggest from "./ons/ONSAutosuggest.svelte";
   export let header = false;
+  export let submitFunction
 </script>
 
 <div class="component-margin--2">
@@ -15,7 +16,7 @@
   <div class="ons-field">
     <p><slot /></p>
     <ONSAutosuggest {labelText} {header} {id} {hint} {autosuggestData} bind:autosuggestValue={userInputValue} />
-    <button type="submit" class="ons-btn ons-u-mt-s ons-btn--small">
+    <button type="submit" class="ons-btn ons-u-mt-s ons-btn--small" on:click={() => submitFunction(userInputValue)}>
       <span class="ons-btn__inner"> {buttonText}</span>
     </button>
   </div>

--- a/src/ui/TopicExplorer.svelte
+++ b/src/ui/TopicExplorer.svelte
@@ -7,6 +7,8 @@
   import { selectedData } from "../model/censusdata/censusdata";
 
   export let selectedTopic;
+  export let locationId;
+  let locationQueryParam = locationId ? `?location=${locationId}` : ""
 
   let topicIndex;
 
@@ -46,7 +48,7 @@
               <a
                 href="/{slugify(topic.name).toLowerCase()}/{slugify(tableEntry.name).toLowerCase()}/{slugify(
                   category.name,
-                ).toLowerCase()}?location=E08000012"
+                ).toLowerCase()}{locationQueryParam}"
                 class="ons-list__link"
                 on:click={() => populatesSelectedData(tableEntry.name, tableEntry.categories, category.code)}
                 >{category.name}</a


### PR DESCRIPTION
This PR sets up the area selected screen, i.e. "/area?location={locationId}", although it also touches on other parts of the 'geography selected' user journey.  Now the user can select an LAD on the index page, and will be redirected to the area selected screen where they have an interactive map showing their chosen LAD.  From this screen they can choose from suggested data options or can browse all data for that LAD at the "/categories?location={locationId}" path.  (I have also extended the map on the categories screen so that it zooms in on the chosen LAD if there is a location query parameter).

Unfortunately it looks like the data structure the ONS Design System autosuggest component is expecting doesn't allow us to associate codes with names at that point, so in terms of data I have created a reverseLadLookup so that we can match LAD names selected on the index page with their codes.

![Screenshot 2021-12-10 at 12 47 43](https://user-images.githubusercontent.com/70749355/145576414-1b8b0f52-6f7a-4406-b75c-c09dc9910ffd.png)