### PR TITLE
Feature/geodata api service

### DIFF
--- a/src/model/censusdata/censusdata.js
+++ b/src/model/censusdata/censusdata.js
@@ -59,8 +59,8 @@ export async function fetchSelectedDataForGeographies(censusDataService, geoCode
 
 export async function fetchSelectedDataForBoundingBox(censusDataService, geoCodes, catCodes) {
   dataService = censusDataService;
-  const data = await dataService.fetchSelectedDataForGeographies(geoCodes, catCodes)
-  mapGeographyData.set([...mapGeographyData, ...data])
+  const data = await dataService.fetchSelectedDataForGeographies(geoCodes, catCodes);
+  mapGeographyData.set([...mapGeographyData, ...data]);
 }
 
 export async function initialiseCensusData(censusDataService) {

--- a/src/model/censusdata/censusdata.js
+++ b/src/model/censusdata/censusdata.js
@@ -57,8 +57,8 @@ export async function fetchSelectedDataForGeographies(censusDataService, geoCode
 }
 
 function filtermapBBoxCodes(dataByGeography, mapBBoxCodes) {
-  if (dataByGeography.length == 0){
-    return mapBBoxCodes
+  if (dataByGeography.length == 0) {
+    return mapBBoxCodes;
   }
   return mapBBoxCodes.filter((item) => !dataByGeography.has(item));
 }
@@ -67,10 +67,10 @@ export async function fetchSelectedDataForNewBoundingBoxGeographies(censusDataSe
   dataService = censusDataService;
   const geoCodes = filtermapBBoxCodes(get(dataByGeography), get(mapBBoxCodes));
   const data = await dataService.fetchSelectedDataForGeographies(geoCodes, catCodes);
-    data.forEach((data, key) => {
-      const catCode = Object.keys(data);
-      get(dataByGeography).set(key, { [catCode]: data[catCode] });
-    });
+  data.forEach((data, key) => {
+    const catCode = Object.keys(data);
+    get(dataByGeography).set(key, { [catCode]: data[catCode] });
+  });
   //temporarily sets store to true to so components can listen for new data
   newDataByGeography.set(true);
   newDataByGeography.set(false);

--- a/src/model/censusdata/censusdata.js
+++ b/src/model/censusdata/censusdata.js
@@ -39,7 +39,6 @@ export function reset() {
 }
 
 export async function fetchAllDataForGeography(censusDataService, geographyCode) {
-  selectedGeographyData.clear();
   dataService = censusDataService;
   const data = await dataService.fetchAllDataForGeography(geographyCode);
   selectedGeographyData.set(data);
@@ -69,7 +68,15 @@ export async function fetchSelectedDataForNewBoundingBoxGeographies(censusDataSe
     const catCode = Object.keys(data)
     get(dataByGeography).set(key, {[catCode]: data[catCode]})
   })
+  //temporarily sets store to true to so components can listen for new data
   newDataByGeography.set(true)
+  newDataByGeography.set(false)
+}
+
+export async function fetchSelectedDataForWholeBoundingBox(censusDataService, geoTypes, catCodes, bBox){
+  dataService = censusDataService;
+  const data = await dataService.fetchSelectedDataForBoundingBox(geoTypes, catCodes, bBox)
+  dataByGeography.set(data)
 }
 
 export async function initialiseCensusData(censusDataService) {

--- a/src/model/censusdata/censusdata.js
+++ b/src/model/censusdata/censusdata.js
@@ -1,5 +1,12 @@
 import { writable } from "svelte/store";
 
+//geodata API stores
+
+export let selectedGeographyData = writable(Map)
+export let mapGeographyData = writable(Map)
+
+
+
 export let censusTableStructureIsLoaded = writable(false);
 export let categoryDataIsLoaded = writable(false);
 export let tableIsLoaded = writable(false);
@@ -31,6 +38,12 @@ export function reset() {
   categories = {};
 
   categoryCodeLookup = {};
+}
+
+export async function fetchAllDataForGeography(censusDataService, geographyCode){
+  dataService = censusDataService
+  const data = await dataService.fetchAllDataForGeography(geographyCode)
+  selectedGeographyData.set(data)
 }
 
 export async function initialiseCensusData(censusDataService) {

--- a/src/model/censusdata/censusdata.js
+++ b/src/model/censusdata/censusdata.js
@@ -56,7 +56,7 @@ export async function fetchSelectedDataForGeographies(censusDataService, geoCode
   dataByGeography.set(data);
 }
 
-function filtermapBBoxCodes(dataByGeography, mapBBoxCodes) {
+function filterOutMapBBoxCodesWithCachedData(dataByGeography, mapBBoxCodes) {
   if (dataByGeography.length == 0) {
     return mapBBoxCodes;
   }
@@ -65,7 +65,7 @@ function filtermapBBoxCodes(dataByGeography, mapBBoxCodes) {
 
 export async function fetchSelectedDataForNewBoundingBoxGeographies(censusDataService, catCodes) {
   dataService = censusDataService;
-  const geoCodes = filtermapBBoxCodes(get(dataByGeography), get(mapBBoxCodes));
+  const geoCodes = filterOutMapBBoxCodesWithCachedData(get(dataByGeography), get(mapBBoxCodes));
   const data = await dataService.fetchSelectedDataForGeographies(geoCodes, catCodes);
   data.forEach((data, key) => {
     const catCode = Object.keys(data);

--- a/src/model/censusdata/censusdata.js
+++ b/src/model/censusdata/censusdata.js
@@ -3,7 +3,7 @@ import { mapBBoxCodes } from "./stores";
 
 export let selectedGeographyData = writable(Map);
 export let dataByGeography = writable(Map);
-export let newDataByGeography = writable(false)
+export let newDataByGeography = writable(false);
 
 export let censusTableStructureIsLoaded = writable(false);
 export let categoryDataIsLoaded = writable(false);
@@ -65,18 +65,18 @@ export async function fetchSelectedDataForNewBoundingBoxGeographies(censusDataSe
   let geoCodes = filtermapBBoxCodes(get(dataByGeography), get(mapBBoxCodes));
   const data = await dataService.fetchSelectedDataForGeographies(geoCodes, catCodes);
   data.forEach((data, key) => {
-    const catCode = Object.keys(data)
-    get(dataByGeography).set(key, {[catCode]: data[catCode]})
-  })
+    const catCode = Object.keys(data);
+    get(dataByGeography).set(key, { [catCode]: data[catCode] });
+  });
   //temporarily sets store to true to so components can listen for new data
-  newDataByGeography.set(true)
-  newDataByGeography.set(false)
+  newDataByGeography.set(true);
+  newDataByGeography.set(false);
 }
 
-export async function fetchSelectedDataForWholeBoundingBox(censusDataService, geoTypes, catCodes, bBox){
+export async function fetchSelectedDataForWholeBoundingBox(censusDataService, geoTypes, catCodes, bBox) {
   dataService = censusDataService;
-  const data = await dataService.fetchSelectedDataForBoundingBox(geoTypes, catCodes, bBox)
-  dataByGeography.set(data)
+  const data = await dataService.fetchSelectedDataForBoundingBox(geoTypes, catCodes, bBox);
+  dataByGeography.set(data);
 }
 
 export async function initialiseCensusData(censusDataService) {

--- a/src/model/censusdata/censusdata.js
+++ b/src/model/censusdata/censusdata.js
@@ -57,6 +57,12 @@ export async function fetchSelectedDataForGeographies(censusDataService, geoCode
   mapGeographyData.set(data);
 }
 
+export async function fetchSelectedDataForBoundingBox(censusDataService, geoCodes, catCodes) {
+  dataService = censusDataService;
+  const data = await dataService.fetchSelectedDataForGeographies(geoCodes, catCodes)
+  mapGeographyData.set([...mapGeographyData, ...data])
+}
+
 export async function initialiseCensusData(censusDataService) {
   dataService = censusDataService;
   await fetchTableStructure();

--- a/src/model/censusdata/censusdata.js
+++ b/src/model/censusdata/censusdata.js
@@ -44,6 +44,12 @@ export async function fetchAllDataForGeography(censusDataService, geographyCode)
   selectedGeographyData.set(data);
 }
 
+export async function fetchSelectedDataForGeoType(censusDataService, geoType, categories){
+  dataService = censusDataService;
+  const data = await dataService.fetchSelectedDataForGeographyType(geoType, categories);
+  mapGeographyData.set(data);
+}
+
 export async function initialiseCensusData(censusDataService) {
   dataService = censusDataService;
   await fetchTableStructure();

--- a/src/model/censusdata/censusdata.js
+++ b/src/model/censusdata/censusdata.js
@@ -2,10 +2,8 @@ import { writable } from "svelte/store";
 
 //geodata API stores
 
-export let selectedGeographyData = writable(Map)
-export let mapGeographyData = writable(Map)
-
-
+export let selectedGeographyData = writable(Map);
+export let mapGeographyData = writable(Map);
 
 export let censusTableStructureIsLoaded = writable(false);
 export let categoryDataIsLoaded = writable(false);
@@ -40,10 +38,10 @@ export function reset() {
   categoryCodeLookup = {};
 }
 
-export async function fetchAllDataForGeography(censusDataService, geographyCode){
-  dataService = censusDataService
-  const data = await dataService.fetchAllDataForGeography(geographyCode)
-  selectedGeographyData.set(data)
+export async function fetchAllDataForGeography(censusDataService, geographyCode) {
+  dataService = censusDataService;
+  const data = await dataService.fetchAllDataForGeography(geographyCode);
+  selectedGeographyData.set(data);
 }
 
 export async function initialiseCensusData(censusDataService) {

--- a/src/model/censusdata/censusdata.js
+++ b/src/model/censusdata/censusdata.js
@@ -1,8 +1,8 @@
 import { writable, get } from "svelte/store";
 import { mapBBoxCodes } from "./stores";
 
-export let selectedGeographyData = writable(Map);
-export let dataByGeography = writable(Map);
+export let selectedGeographyData = writable(new Map());
+export let dataByGeography = writable(new Map());
 export let newDataByGeography = writable(false);
 
 export let censusTableStructureIsLoaded = writable(false);
@@ -57,17 +57,20 @@ export async function fetchSelectedDataForGeographies(censusDataService, geoCode
 }
 
 function filtermapBBoxCodes(dataByGeography, mapBBoxCodes) {
+  if (dataByGeography.length == 0){
+    return mapBBoxCodes
+  }
   return mapBBoxCodes.filter((item) => !dataByGeography.has(item));
 }
 
 export async function fetchSelectedDataForNewBoundingBoxGeographies(censusDataService, catCodes) {
   dataService = censusDataService;
-  let geoCodes = filtermapBBoxCodes(get(dataByGeography), get(mapBBoxCodes));
+  const geoCodes = filtermapBBoxCodes(get(dataByGeography), get(mapBBoxCodes));
   const data = await dataService.fetchSelectedDataForGeographies(geoCodes, catCodes);
-  data.forEach((data, key) => {
-    const catCode = Object.keys(data);
-    get(dataByGeography).set(key, { [catCode]: data[catCode] });
-  });
+    data.forEach((data, key) => {
+      const catCode = Object.keys(data);
+      get(dataByGeography).set(key, { [catCode]: data[catCode] });
+    });
   //temporarily sets store to true to so components can listen for new data
   newDataByGeography.set(true);
   newDataByGeography.set(false);

--- a/src/model/censusdata/censusdata.js
+++ b/src/model/censusdata/censusdata.js
@@ -1,6 +1,5 @@
-import { writable } from "svelte/store";
-
-//geodata API stores
+import { writable, get } from "svelte/store";
+import { mapBboxCodes } from "./stores";
 
 export let selectedGeographyData = writable(Map);
 export let mapGeographyData = writable(Map);
@@ -57,8 +56,13 @@ export async function fetchSelectedDataForGeographies(censusDataService, geoCode
   mapGeographyData.set(data);
 }
 
-export async function fetchSelectedDataForBoundingBox(censusDataService, geoCodes, catCodes) {
+function filterMapBboxCodes(mapGeographyData, mapBboxCodes) {
+  return mapBboxCodes.filter((item) => !mapGeographyData.has(item));
+}
+
+export async function fetchSelectedDataForBoundingBox(censusDataService, catCodes) {
   dataService = censusDataService;
+  let geoCodes = filterMapBboxCodes(get(mapGeographyData), get(mapBboxCodes));
   const data = await dataService.fetchSelectedDataForGeographies(geoCodes, catCodes);
   mapGeographyData.set([...mapGeographyData, ...data]);
 }

--- a/src/model/censusdata/censusdata.js
+++ b/src/model/censusdata/censusdata.js
@@ -1,9 +1,9 @@
 import { writable, get } from "svelte/store";
-import { mapBBoxCodes } from "./stores";
+import { mapBBoxCodes, toggleable } from "./stores";
 
 export let selectedGeographyData = writable(new Map());
 export let dataByGeography = writable(new Map());
-export let newDataByGeography = writable(false);
+export let newDataByGeography = toggleable(false);
 
 export let censusTableStructureIsLoaded = writable(false);
 export let categoryDataIsLoaded = writable(false);
@@ -72,8 +72,7 @@ export async function fetchSelectedDataForNewBoundingBoxGeographies(censusDataSe
     get(dataByGeography).set(key, { [catCode]: data[catCode] });
   });
   //temporarily sets store to true to so components can listen for new data
-  newDataByGeography.set(true);
-  newDataByGeography.set(false);
+  newDataByGeography.notify()
 }
 
 export async function fetchSelectedDataForWholeBoundingBox(censusDataService, geoTypes, catCodes, bBox) {

--- a/src/model/censusdata/censusdata.js
+++ b/src/model/censusdata/censusdata.js
@@ -39,14 +39,21 @@ export function reset() {
 }
 
 export async function fetchAllDataForGeography(censusDataService, geographyCode) {
+  selectedGeographyData.clear();
   dataService = censusDataService;
   const data = await dataService.fetchAllDataForGeography(geographyCode);
   selectedGeographyData.set(data);
 }
 
-export async function fetchSelectedDataForGeoType(censusDataService, geoType, categories){
+export async function fetchSelectedDataForGeoType(censusDataService, geoType, categories) {
   dataService = censusDataService;
   const data = await dataService.fetchSelectedDataForGeographyType(geoType, categories);
+  mapGeographyData.set(data);
+}
+
+export async function fetchSelectedDataForGeographies(censusDataService, geoCodes, catCodes) {
+  dataService = censusDataService;
+  const data = await dataService.fetchSelectedDataForGeographies(geoCodes, catCodes);
   mapGeographyData.set(data);
 }
 

--- a/src/model/censusdata/censusdata.js
+++ b/src/model/censusdata/censusdata.js
@@ -1,8 +1,9 @@
 import { writable, get } from "svelte/store";
-import { mapBboxCodes } from "./stores";
+import { mapBBoxCodes } from "./stores";
 
 export let selectedGeographyData = writable(Map);
-export let mapGeographyData = writable(Map);
+export let dataByGeography = writable(Map);
+export let newDataByGeography = writable(false)
 
 export let censusTableStructureIsLoaded = writable(false);
 export let categoryDataIsLoaded = writable(false);
@@ -47,24 +48,28 @@ export async function fetchAllDataForGeography(censusDataService, geographyCode)
 export async function fetchSelectedDataForGeoType(censusDataService, geoType, categories) {
   dataService = censusDataService;
   const data = await dataService.fetchSelectedDataForGeographyType(geoType, categories);
-  mapGeographyData.set(data);
+  dataByGeography.set(data);
 }
 
 export async function fetchSelectedDataForGeographies(censusDataService, geoCodes, catCodes) {
   dataService = censusDataService;
   const data = await dataService.fetchSelectedDataForGeographies(geoCodes, catCodes);
-  mapGeographyData.set(data);
+  dataByGeography.set(data);
 }
 
-function filterMapBboxCodes(mapGeographyData, mapBboxCodes) {
-  return mapBboxCodes.filter((item) => !mapGeographyData.has(item));
+function filtermapBBoxCodes(dataByGeography, mapBBoxCodes) {
+  return mapBBoxCodes.filter((item) => !dataByGeography.has(item));
 }
 
-export async function fetchSelectedDataForBoundingBox(censusDataService, catCodes) {
+export async function fetchSelectedDataForNewBoundingBoxGeographies(censusDataService, catCodes) {
   dataService = censusDataService;
-  let geoCodes = filterMapBboxCodes(get(mapGeographyData), get(mapBboxCodes));
+  let geoCodes = filtermapBBoxCodes(get(dataByGeography), get(mapBBoxCodes));
   const data = await dataService.fetchSelectedDataForGeographies(geoCodes, catCodes);
-  mapGeographyData.set([...mapGeographyData, ...data]);
+  data.forEach((data, key) => {
+    const catCode = Object.keys(data)
+    get(dataByGeography).set(key, {[catCode]: data[catCode]})
+  })
+  newDataByGeography.set(true)
 }
 
 export async function initialiseCensusData(censusDataService) {

--- a/src/model/censusdata/services/geodataApiDataService.js
+++ b/src/model/censusdata/services/geodataApiDataService.js
@@ -64,30 +64,45 @@ export default class GeodataApiDataService {
   // }
 
   async fetchSelectedDataForGeographyType(geoType, categories) {
-    const categoriesString = categories.toString()
-    let url = ""
+    const categoriesString = categories.toString();
+    let url = "";
     if (geoType.toLowerCase().trim() == "lad") {
-      url = `${baseURL}?cols=geography_code,${categoriesString}&geotype=LAD`
+      url = `${baseURL}?cols=geography_code,${categoriesString}&geotype=LAD`;
     } else if (geoType.toLowerCase().trim() == "lsoa") {
-      url = `${baseURL}?cols=geography_code,${categoriesString}&geotype=LSOA`
+      url = `${baseURL}?cols=geography_code,${categoriesString}&geotype=LSOA`;
     }
     const response = await fetch(url);
     const string = await response.text();
     let data = new Map();
     csvParse(string, (row, i, cols) => {
-      let geoDataObject = {}
+      let geoDataObject = {};
       cols.forEach((col, i) => {
         if (i > 0) {
-          geoDataObject[col] = +row[col]
+          geoDataObject[col] = +row[col];
         }
-      })
-      data.set(row.geography_code, geoDataObject)
-      })
-    return data
+      });
+      data.set(row.geography_code, geoDataObject);
+    });
+    return data;
   }
 
-  async fetchSelectedDataForGeographies() {
-    //if single selected geography, separate selectedGeography store?
+  async fetchSelectedDataForGeographies(geoCodes, catCodes) {
+    const geoCodesString = geoCodes.toString();
+    const catCodesString = catCodes.toString();
+    const url = `${baseURL}?cols=geography_code,${catCodesString}&rows=${geoCodesString}`;
+    const response = await fetch(url);
+    const string = await response.text();
+    let data = new Map();
+    csvParse(string, (row, i, cols) => {
+      let geoDataObject = {};
+      cols.forEach((col, i) => {
+        if (i > 0) {
+          geoDataObject[col] = +row[col];
+        }
+      });
+      data.set(row.geography_code, geoDataObject);
+    });
+    return data;
   }
 
   async fetchSelectedDataForBoundingBox() {

--- a/src/model/censusdata/services/geodataApiDataService.js
+++ b/src/model/censusdata/services/geodataApiDataService.js
@@ -1,6 +1,5 @@
 import { csvParse } from "d3-dsv";
 
-
 const baseURL = "https://5laefo1cxd.execute-api.eu-central-1.amazonaws.com/dev/hello/skinny";
 
 export default class GeodataApiDataService {
@@ -31,29 +30,28 @@ export default class GeodataApiDataService {
   }
 
   async fetchAllDataForGeography(geographyId) {
-    const url = `${baseURL}?rows=${geographyId}`
-    const response = await fetch(url)
-    const string = await response.text()
-    let data = new Map()
+    const url = `${baseURL}?rows=${geographyId}`;
+    const response = await fetch(url);
+    const string = await response.text();
+    let data = new Map();
     csvParse(string, (row, i, cols) => {
-        cols.forEach((col, i) => {
-          if (i ==0) {
-            data.set("geographyId", row[cols[0]])
-          } else {
-          data.set(col, +row[col])
-          }
-        })
-      })
-    return data
+      cols.forEach((col, i) => {
+        if (i == 0) {
+          data.set("geographyId", row[cols[0]]);
+        } else {
+          data.set(col, +row[col]);
+        }
+      });
+    });
+    return data;
   }
 
-// selectedGeographyData store  
-// {
-//   geographyCode: {
-//     catCode: 50
-//   }
-// }
-
+  // selectedGeographyData store
+  // {
+  //   geographyCode: {
+  //     catCode: 50
+  //   }
+  // }
 
   // mapGeographyData store:
   // {
@@ -65,16 +63,15 @@ export default class GeodataApiDataService {
   //   }
   // }
 
-  async fetchSelectedDataForGeographyType(){
-      //load all data for LADs when selecting a category?
+  async fetchSelectedDataForGeographyType() {
+    //load all data for LADs when selecting a category?
   }
 
-  async fetchSelectedDataForGeographies(){
+  async fetchSelectedDataForGeographies() {
     //if single selected geography, separate selectedGeography store?
-
   }
 
-  async fetchSelectedDataForBoundingBox(){
+  async fetchSelectedDataForBoundingBox() {
     //presumably this will only be called given a certain zoom level
   }
 

--- a/src/model/censusdata/services/geodataApiDataService.js
+++ b/src/model/censusdata/services/geodataApiDataService.js
@@ -63,8 +63,27 @@ export default class GeodataApiDataService {
   //   }
   // }
 
-  async fetchSelectedDataForGeographyType() {
-    //load all data for LADs when selecting a category?
+  async fetchSelectedDataForGeographyType(geoType, categories) {
+    const categoriesString = categories.toString()
+    let url = ""
+    if (geoType.toLowerCase().trim() == "lad") {
+      url = `${baseURL}?cols=geography_code,${categoriesString}&geotype=LAD`
+    } else if (geoType.toLowerCase().trim() == "lsoa") {
+      url = `${baseURL}?cols=geography_code,${categoriesString}&geotype=LSOA`
+    }
+    const response = await fetch(url);
+    const string = await response.text();
+    let data = new Map();
+    csvParse(string, (row, i, cols) => {
+      let geoDataObject = {}
+      cols.forEach((col, i) => {
+        if (i > 0) {
+          geoDataObject[col] = +row[col]
+        }
+      })
+      data.set(row.geography_code, geoDataObject)
+      })
+    return data
   }
 
   async fetchSelectedDataForGeographies() {

--- a/src/model/censusdata/services/geodataApiDataService.js
+++ b/src/model/censusdata/services/geodataApiDataService.js
@@ -1,8 +1,5 @@
 import { csvParse } from "d3-dsv";
-import { ckmeans } from "simple-statistics";
-import { lsoaLookup } from "../../geography/geography
-import config from "../../../config
-import simpleTopicTableCategoryData from "../../../data/simpleTopicTableCategoryData";
+
 
 const baseURL = "https://5laefo1cxd.execute-api.eu-central-1.amazonaws.com/dev/hello/skinny";
 
@@ -37,26 +34,51 @@ export default class GeodataApiDataService {
     const url = `${baseURL}?rows=${geographyId}`
     const response = await fetch(url)
     const string = await response.text()
+    let data = new Map()
     csvParse(string, (row, i, cols) => {
-      cols.forEach((col) => {
-        //write to store as set
+        cols.forEach((col, i) => {
+          if (i ==0) {
+            data.set("geographyId", row[cols[0]])
+          } else {
+          data.set(col, +row[col])
+          }
+        })
       })
-    })
-
+    return data
   }
 
-  async fetchSelectedDataForGeography(){
+// selectedGeographyData store  
+// {
+//   geographyCode: {
+//     catCode: 50
+//   }
+// }
 
+
+  // mapGeographyData store:
+  // {
+  //   geoCode: {
+  //     catCode: {
+  //       number: 99
+  //       total: 100
+  //     }
+  //   }
+  // }
+
+  async fetchSelectedDataForGeographyType(){
+      //load all data for LADs when selecting a category?
   }
 
-  async fetchSelectedDataForMultipleGeographies(){
+  async fetchSelectedDataForGeographies(){
+    //if single selected geography, separate selectedGeography store?
 
   }
 
   async fetchSelectedDataForBoundingBox(){
-
+    //presumably this will only be called given a certain zoom level
   }
 
   async fetchCensusTableStructure() {
     return simpleTopicTableCategoryData;
   }
+}

--- a/src/model/censusdata/services/geodataApiDataService.js
+++ b/src/model/censusdata/services/geodataApiDataService.js
@@ -53,7 +53,7 @@ export default class GeodataApiDataService {
   //   }
   // }
 
-  // mapGeographyData store:
+  // dataByGeography store:
   // {
   //   geoCode: {
   //     catCode: {

--- a/src/model/censusdata/services/geodataApiDataService.js
+++ b/src/model/censusdata/services/geodataApiDataService.js
@@ -4,15 +4,15 @@ import { writeDataToMapObj } from "../../utils";
 const baseURL = "https://5laefo1cxd.execute-api.eu-central-1.amazonaws.com/dev/hello/skinny";
 
 export default class GeodataApiDataService {
-  async fetchAllDataForGeography(geographyId) {
-    const url = `${baseURL}?rows=${geographyId}`;
+  async fetchAllDataForGeography(geographyCode) {
+    const url = `${baseURL}?rows=${geographyCode}`;
     const response = await fetch(url);
     const string = await response.text();
     let data = new Map();
     csvParse(string, (row, i, cols) => {
       cols.forEach((col, i) => {
         if (i == 0) {
-          data.set("geographyId", row[cols[0]]);
+          data.set("geographyCode", row[cols[0]]);
         } else {
           data.set(col, +row[col]);
         }

--- a/src/model/censusdata/services/geodataApiDataService.js
+++ b/src/model/censusdata/services/geodataApiDataService.js
@@ -1,0 +1,62 @@
+import { csvParse } from "d3-dsv";
+import { ckmeans } from "simple-statistics";
+import { lsoaLookup } from "../../geography/geography
+import config from "../../../config
+import simpleTopicTableCategoryData from "../../../data/simpleTopicTableCategoryData";
+
+const baseURL = "https://5laefo1cxd.execute-api.eu-central-1.amazonaws.com/dev/hello/skinny";
+
+export default class GeodataApiDataService {
+  constructor() {
+    this.reset();
+  }
+
+  reset() {
+    this.dataset = {
+      lsoa: {
+        data: [],
+        index: {},
+        breaks: [],
+      },
+      higher: {
+        data: [],
+        index: {},
+      },
+      lad: {
+        data: [],
+        index: {},
+      },
+      englandAndWales: {
+        count: 0,
+        value: 0,
+      },
+    };
+  }
+
+  async fetchAllDataForGeography(geographyId) {
+    const url = `${baseURL}?rows=${geographyId}`
+    const response = await fetch(url)
+    const string = await response.text()
+    csvParse(string, (row, i, cols) => {
+      cols.forEach((col) => {
+        //write to store as set
+      })
+    })
+
+  }
+
+  async fetchSelectedDataForGeography(){
+
+  }
+
+  async fetchSelectedDataForMultipleGeographies(){
+
+  }
+
+  async fetchSelectedDataForBoundingBox(){
+
+  }
+
+  async fetchCensusTableStructure() {
+    return simpleTopicTableCategoryData;
+  }

--- a/src/model/censusdata/services/geodataApiDataService.js
+++ b/src/model/censusdata/services/geodataApiDataService.js
@@ -1,5 +1,5 @@
 import { csvParse } from "d3-dsv";
-import {writeDataToMapObj} from "../../utils"
+import { writeDataToMapObj } from "../../utils";
 
 const baseURL = "https://5laefo1cxd.execute-api.eu-central-1.amazonaws.com/dev/hello/skinny";
 

--- a/src/model/censusdata/services/geodataApiDataService.js
+++ b/src/model/censusdata/services/geodataApiDataService.js
@@ -3,31 +3,7 @@ import { csvParse } from "d3-dsv";
 const baseURL = "https://5laefo1cxd.execute-api.eu-central-1.amazonaws.com/dev/hello/skinny";
 
 export default class GeodataApiDataService {
-  constructor() {
-    this.reset();
-  }
-
-  reset() {
-    this.dataset = {
-      lsoa: {
-        data: [],
-        index: {},
-        breaks: [],
-      },
-      higher: {
-        data: [],
-        index: {},
-      },
-      lad: {
-        data: [],
-        index: {},
-      },
-      englandAndWales: {
-        count: 0,
-        value: 0,
-      },
-    };
-  }
+  
 
   async fetchAllDataForGeography(geographyId) {
     const url = `${baseURL}?rows=${geographyId}`;
@@ -45,23 +21,6 @@ export default class GeodataApiDataService {
     });
     return data;
   }
-
-  // selectedGeographyData store
-  // {
-  //   geographyCode: {
-  //     catCode: 50
-  //   }
-  // }
-
-  // dataByGeography store:
-  // {
-  //   geoCode: {
-  //     catCode: {
-  //       number: 99
-  //       total: 100
-  //     }
-  //   }
-  // }
 
   async fetchSelectedDataForGeographyType(geoType, categories) {
     const categoriesString = categories.toString();
@@ -105,8 +64,23 @@ export default class GeodataApiDataService {
     return data;
   }
 
-  async fetchSelectedDataForBoundingBox() {
-    //presumably this will only be called given a certain zoom level
+  async fetchSelectedDataForBoundingBox(geoType, catCodes, bBox) {
+    const geoTypesString = geoType.toString();
+    const catCodesString = catCodes.toString()
+    const url = `${baseURL}?bbox=${bBox.neCorner.lng},${bBox.neCorner.lat},${bBox.swCorner.lng},${bBox.swCorner.lat}&cols=geography_code,${catCodesString}&geotype=${geoTypesString}`
+    const response = await fetch(url)
+    const string = await response.text()
+    let data = new Map()
+    csvParse(string, (row, i, cols) => {
+      let geoDataObject = {};
+      cols.forEach((col, i) => {
+        if (i > 0) {
+          geoDataObject[col] = +row[col];
+        }
+      });
+      data.set(row.geography_code, geoDataObject);
+    });
+    return data;
   }
 
   async fetchCensusTableStructure() {

--- a/src/model/censusdata/services/geodataApiDataService.js
+++ b/src/model/censusdata/services/geodataApiDataService.js
@@ -3,8 +3,6 @@ import { csvParse } from "d3-dsv";
 const baseURL = "https://5laefo1cxd.execute-api.eu-central-1.amazonaws.com/dev/hello/skinny";
 
 export default class GeodataApiDataService {
-  
-
   async fetchAllDataForGeography(geographyId) {
     const url = `${baseURL}?rows=${geographyId}`;
     const response = await fetch(url);
@@ -66,11 +64,11 @@ export default class GeodataApiDataService {
 
   async fetchSelectedDataForBoundingBox(geoType, catCodes, bBox) {
     const geoTypesString = geoType.toString();
-    const catCodesString = catCodes.toString()
-    const url = `${baseURL}?bbox=${bBox.neCorner.lng},${bBox.neCorner.lat},${bBox.swCorner.lng},${bBox.swCorner.lat}&cols=geography_code,${catCodesString}&geotype=${geoTypesString}`
-    const response = await fetch(url)
-    const string = await response.text()
-    let data = new Map()
+    const catCodesString = catCodes.toString();
+    const url = `${baseURL}?bbox=${bBox.neCorner.lng},${bBox.neCorner.lat},${bBox.swCorner.lng},${bBox.swCorner.lat}&cols=geography_code,${catCodesString}&geotype=${geoTypesString}`;
+    const response = await fetch(url);
+    const string = await response.text();
+    let data = new Map();
     csvParse(string, (row, i, cols) => {
       let geoDataObject = {};
       cols.forEach((col, i) => {

--- a/src/model/censusdata/services/geodataApiDataService.js
+++ b/src/model/censusdata/services/geodataApiDataService.js
@@ -1,4 +1,5 @@
 import { csvParse } from "d3-dsv";
+import {writeDataToMapObj} from "../../utils"
 
 const baseURL = "https://5laefo1cxd.execute-api.eu-central-1.amazonaws.com/dev/hello/skinny";
 
@@ -30,17 +31,7 @@ export default class GeodataApiDataService {
     }
     const response = await fetch(url);
     const string = await response.text();
-    let data = new Map();
-    csvParse(string, (row, i, cols) => {
-      let geoDataObject = {};
-      cols.forEach((col, i) => {
-        if (i > 0) {
-          geoDataObject[col] = +row[col];
-        }
-      });
-      data.set(row.geography_code, geoDataObject);
-    });
-    return data;
+    return writeDataToMapObj(string);
   }
 
   async fetchSelectedDataForGeographies(geoCodes, catCodes) {
@@ -49,17 +40,7 @@ export default class GeodataApiDataService {
     const url = `${baseURL}?cols=geography_code,${catCodesString}&rows=${geoCodesString}`;
     const response = await fetch(url);
     const string = await response.text();
-    let data = new Map();
-    csvParse(string, (row, i, cols) => {
-      let geoDataObject = {};
-      cols.forEach((col, i) => {
-        if (i > 0) {
-          geoDataObject[col] = +row[col];
-        }
-      });
-      data.set(row.geography_code, geoDataObject);
-    });
-    return data;
+    return writeDataToMapObj(string);
   }
 
   async fetchSelectedDataForBoundingBox(geoType, catCodes, bBox) {
@@ -68,20 +49,6 @@ export default class GeodataApiDataService {
     const url = `${baseURL}?bbox=${bBox.neCorner.lng},${bBox.neCorner.lat},${bBox.swCorner.lng},${bBox.swCorner.lat}&cols=geography_code,${catCodesString}&geotype=${geoTypesString}`;
     const response = await fetch(url);
     const string = await response.text();
-    let data = new Map();
-    csvParse(string, (row, i, cols) => {
-      let geoDataObject = {};
-      cols.forEach((col, i) => {
-        if (i > 0) {
-          geoDataObject[col] = +row[col];
-        }
-      });
-      data.set(row.geography_code, geoDataObject);
-    });
-    return data;
-  }
-
-  async fetchCensusTableStructure() {
-    return simpleTopicTableCategoryData;
+    return writeDataToMapObj(string);
   }
 }

--- a/src/model/censusdata/services/legacyCensusDataService.js
+++ b/src/model/censusdata/services/legacyCensusDataService.js
@@ -71,10 +71,10 @@ export default class LegacyCensusDataService {
     };
   }
 
-  async fetchTableForGeography(tableId, geographyId) {
+  async fetchTableForGeography(tableId, geographyCode) {
     return {
       tableId: tableId,
-      geographyId: geographyId,
+      geographyCode: geographyCode,
       rows: [
         // { category: 'Female', value: 4801, perc: 0.49 }
       ],

--- a/src/model/censusdata/services/mockCensusDataService.js
+++ b/src/model/censusdata/services/mockCensusDataService.js
@@ -13,10 +13,10 @@ export default class MockCensusDataService {
 
   async fetchCategoryAggregateData(categoryId) {}
 
-  async fetchTableForGeography(tableId, geographyId) {
+  async fetchTableForGeography(tableId, geographyCode) {
     return {
       tableId: tableId,
-      geographyId: geographyId,
+      geographyCode: geographyCode,
       rows: [
         // { category: 'Female', value: 4801, perc: 0.49 }
       ],

--- a/src/model/censusdata/stores.js
+++ b/src/model/censusdata/stores.js
@@ -1,0 +1,3 @@
+import { writable } from "svelte/store";
+
+export let mapBboxCodes = writable([]);

--- a/src/model/censusdata/stores.js
+++ b/src/model/censusdata/stores.js
@@ -1,3 +1,3 @@
 import { writable } from "svelte/store";
 
-export let mapBboxCodes = writable([]);
+export let mapBBoxCodes = writable([]);

--- a/src/model/censusdata/stores.js
+++ b/src/model/censusdata/stores.js
@@ -1,3 +1,15 @@
 import { writable } from "svelte/store";
 
 export let mapBBoxCodes = writable([]);
+	
+export const toggleable = initial => {
+    const store = writable(initial);
+
+    return {
+        ...store,
+        notify: () => {
+            store.update(n => !n)
+            store.update(n => !n)
+        },
+    };
+};

--- a/src/model/geography/geography.js
+++ b/src/model/geography/geography.js
@@ -126,3 +126,11 @@ function buildLsoaLookup(lsoaData) {
   });
   return lsoaLookup;
 }
+
+export function setMapBBoxGeoCodes(map, mapBboxCodes) {
+  const bBoxCodes = map
+    .queryRenderedFeatures({ layers: ["lad-interactive-layer", "lsoa-boundaries"] })
+    .map((feature) => feature.id);
+  const filteredCodes = [...new Set(bBoxCodes)];
+  mapBboxCodes.set(filteredCodes);
+}

--- a/src/model/geography/geography.js
+++ b/src/model/geography/geography.js
@@ -127,10 +127,9 @@ function buildLsoaLookup(lsoaData) {
   return lsoaLookup;
 }
 
-export function setMapBBoxGeoCodes(map, mapBboxCodes) {
+export function getMapBBoxGeoCodes(map) {
   const bBoxCodes = map
     .queryRenderedFeatures({ layers: ["lad-interactive-layer", "lsoa-boundaries"] })
     .map((feature) => feature.id);
-  const filteredCodes = [...new Set(bBoxCodes)];
-  mapBboxCodes.set(filteredCodes);
+  return [...new Set(bBoxCodes)];
 }

--- a/src/model/geography/stores.js
+++ b/src/model/geography/stores.js
@@ -1,0 +1,3 @@
+import { writable } from "svelte/store";
+
+export let mapZoomBBox = writable({});

--- a/src/model/geography/stores.js
+++ b/src/model/geography/stores.js
@@ -1,3 +1,3 @@
 import { writable } from "svelte/store";
 
-export let mapZoomBBox = writable({});
+export let mapZoomBBox = writable(null);

--- a/src/model/utils.js
+++ b/src/model/utils.js
@@ -9,16 +9,16 @@ export function getLegendSection(value, breakpoints) {
   return breakpoints.length;
 }
 
-export function writeDataToMapObj(responseStr){
+export function writeDataToMapObj(responseStr) {
   let data = new Map();
-    csvParse(responseStr, (row, i, cols) => {
-      let geoDataObject = {};
-      cols.forEach((col, i) => {
-        if (i > 0) {
-          geoDataObject[col] = +row[col];
-        }
-      });
-      data.set(row.geography_code, geoDataObject);
+  csvParse(responseStr, (row, i, cols) => {
+    let geoDataObject = {};
+    cols.forEach((col, i) => {
+      if (i > 0) {
+        geoDataObject[col] = +row[col];
+      }
     });
-  return data
+    data.set(row.geography_code, geoDataObject);
+  });
+  return data;
 }

--- a/src/model/utils.js
+++ b/src/model/utils.js
@@ -1,3 +1,5 @@
+import { csvParse } from "d3-dsv";
+
 export function getLegendSection(value, breakpoints) {
   for (let i = 1; i < breakpoints.length; i++) {
     if (value <= breakpoints[i]) {
@@ -5,4 +7,18 @@ export function getLegendSection(value, breakpoints) {
     }
   }
   return breakpoints.length;
+}
+
+export function writeDataToMapObj(responseStr){
+  let data = new Map();
+    csvParse(responseStr, (row, i, cols) => {
+      let geoDataObject = {};
+      cols.forEach((col, i) => {
+        if (i > 0) {
+          geoDataObject[col] = +row[col];
+        }
+      });
+      data.set(row.geography_code, geoDataObject);
+    });
+  return data
 }

--- a/src/routes/[topicSlug]/[tableSlug]/[categorySlug].svelte
+++ b/src/routes/[topicSlug]/[tableSlug]/[categorySlug].svelte
@@ -36,6 +36,13 @@
   import DataLayer from "../../../ui/map/DataLayer.svelte";
   import { appIsInitialised } from "../../../model/appstate";
   import { isNotEmpty } from "../../../utils";
+  import {
+    mapGeographyData,
+    fetchSelectedDataForBoundingBox,
+    fetchSelectedDataForGeographies,
+  } from "../../../model/censusdata/censusdata";
+  import GeodataApiDataService from "../../../model/censusdata/services/geodataApiDataService";
+  import { mapBboxCodes } from "../../../model/censusdata/stores";
 
   import { page } from "$app/stores";
   import { onMount } from "svelte";
@@ -47,6 +54,16 @@
   let locationId = null;
   let locationName = "";
   locationId = $page.query.get("location");
+
+  fetchSelectedDataForGeographies(
+    new GeodataApiDataService(),
+    ["E06000001", "E06000002", "E06000003"],
+    ["QS802EW0001"],
+  );
+  $: console.log("mapGeographyData", $mapGeographyData);
+
+  $: mapBboxCodes, fetchSelectedDataForBoundingBox(new GeodataApiDataService(), ["QS802EW0001"]);
+
   onMount(async () => {
     if (locationId) {
       updateSelectedGeography(locationId);

--- a/src/routes/[topicSlug]/[tableSlug]/[categorySlug].svelte
+++ b/src/routes/[topicSlug]/[tableSlug]/[categorySlug].svelte
@@ -51,7 +51,7 @@
 
   import { page } from "$app/stores";
   import { onMount } from "svelte";
-import { mapZoomBBox } from "../../../model/geography/stores";
+  import { mapZoomBBox } from "../../../model/geography/stores";
 
   let { topicSlug, tableSlug, categorySlug } = $page.params;
   let category = null;
@@ -65,18 +65,15 @@ import { mapZoomBBox } from "../../../model/geography/stores";
   //   fetchSelectedDataForWholeBoundingBox(new GeodataApiDataService(), ['LSOA'], ["QS802EW0001"], $mapZoomBBox)
   // }
 
-  $: console.log("selectedGeographyData", $selectedGeographyData)
+  $: console.log("selectedGeographyData", $selectedGeographyData);
 
   setTimeout(() => {
-    fetchAllDataForGeography(
-    new GeodataApiDataService(),
-    "W06000023",
-  );
-  }, 4000)
+    fetchAllDataForGeography(new GeodataApiDataService(), "W06000023");
+  }, 4000);
 
   // $: $newDataByGeography, console.log("NEW dataByGeography", $dataByGeography);
 
-  // $: if ($mapBBoxCodes){ 
+  // $: if ($mapBBoxCodes){
   //   console.log($mapBBoxCodes)
   //   fetchSelectedDataForNewBoundingBoxGeographies(new GeodataApiDataService(), ["QS802EW0001"]);
   // }

--- a/src/routes/[topicSlug]/[tableSlug]/[categorySlug].svelte
+++ b/src/routes/[topicSlug]/[tableSlug]/[categorySlug].svelte
@@ -39,14 +39,19 @@
   import { isNotEmpty } from "../../../utils";
   import {
     dataByGeography,
+    selectedGeographyData,
+    fetchAllDataForGeography,
+    fetchSelectedDataForGeoType,
     fetchSelectedDataForNewBoundingBoxGeographies,
     fetchSelectedDataForGeographies,
+    fetchSelectedDataForWholeBoundingBox,
   } from "../../../model/censusdata/censusdata";
   import GeodataApiDataService from "../../../model/censusdata/services/geodataApiDataService";
   import { mapBBoxCodes } from "../../../model/censusdata/stores";
 
   import { page } from "$app/stores";
   import { onMount } from "svelte";
+import { mapZoomBBox } from "../../../model/geography/stores";
 
   let { topicSlug, tableSlug, categorySlug } = $page.params;
   let category = null;
@@ -56,15 +61,25 @@
   let locationName = "";
   locationId = $page.query.get("location");
 
-  fetchSelectedDataForGeographies(
+  // $: if ($mapZoomBBox) {
+  //   fetchSelectedDataForWholeBoundingBox(new GeodataApiDataService(), ['LSOA'], ["QS802EW0001"], $mapZoomBBox)
+  // }
+
+  $: console.log("selectedGeographyData", $selectedGeographyData)
+
+  setTimeout(() => {
+    fetchAllDataForGeography(
     new GeodataApiDataService(),
-    ["E06000001", "E06000002", "E06000003"],
-    ["QS802EW0001"],
+    "W06000023",
   );
+  }, 4000)
 
-  $: $newDataByGeography, console.log("dataByGeography", $dataByGeography);
+  // $: $newDataByGeography, console.log("NEW dataByGeography", $dataByGeography);
 
-  $: $mapBBoxCodes, fetchSelectedDataForNewBoundingBoxGeographies(new GeodataApiDataService(), ["QS802EW0001"]);
+  // $: if ($mapBBoxCodes){ 
+  //   console.log($mapBBoxCodes)
+  //   fetchSelectedDataForNewBoundingBoxGeographies(new GeodataApiDataService(), ["QS802EW0001"]);
+  // }
 
   onMount(async () => {
     if (locationId) {

--- a/src/routes/[topicSlug]/[tableSlug]/[categorySlug].svelte
+++ b/src/routes/[topicSlug]/[tableSlug]/[categorySlug].svelte
@@ -22,6 +22,7 @@
     getCategoryBySlug,
     populatesSelectedData,
     selectedData,
+    newDataByGeography,
   } from "../../../model/censusdata/censusdata";
   import {
     updateHoveredGeography,
@@ -37,12 +38,12 @@
   import { appIsInitialised } from "../../../model/appstate";
   import { isNotEmpty } from "../../../utils";
   import {
-    mapGeographyData,
-    fetchSelectedDataForBoundingBox,
+    dataByGeography,
+    fetchSelectedDataForNewBoundingBoxGeographies,
     fetchSelectedDataForGeographies,
   } from "../../../model/censusdata/censusdata";
   import GeodataApiDataService from "../../../model/censusdata/services/geodataApiDataService";
-  import { mapBboxCodes } from "../../../model/censusdata/stores";
+  import { mapBBoxCodes } from "../../../model/censusdata/stores";
 
   import { page } from "$app/stores";
   import { onMount } from "svelte";
@@ -60,9 +61,10 @@
     ["E06000001", "E06000002", "E06000003"],
     ["QS802EW0001"],
   );
-  $: console.log("mapGeographyData", $mapGeographyData);
 
-  $: mapBboxCodes, fetchSelectedDataForBoundingBox(new GeodataApiDataService(), ["QS802EW0001"]);
+  $: $newDataByGeography, console.log("dataByGeography", $dataByGeography);
+
+  $: $mapBBoxCodes, fetchSelectedDataForNewBoundingBoxGeographies(new GeodataApiDataService(), ["QS802EW0001"]);
 
   onMount(async () => {
     if (locationId) {

--- a/src/routes/[topicSlug]/[tableSlug]/[categorySlug].svelte
+++ b/src/routes/[topicSlug]/[tableSlug]/[categorySlug].svelte
@@ -22,7 +22,6 @@
     getCategoryBySlug,
     populatesSelectedData,
     selectedData,
-    newDataByGeography,
   } from "../../../model/censusdata/censusdata";
   import {
     updateHoveredGeography,
@@ -37,21 +36,9 @@
   import DataLayer from "../../../ui/map/DataLayer.svelte";
   import { appIsInitialised } from "../../../model/appstate";
   import { isNotEmpty } from "../../../utils";
-  import {
-    dataByGeography,
-    selectedGeographyData,
-    fetchAllDataForGeography,
-    fetchSelectedDataForGeoType,
-    fetchSelectedDataForNewBoundingBoxGeographies,
-    fetchSelectedDataForGeographies,
-    fetchSelectedDataForWholeBoundingBox,
-  } from "../../../model/censusdata/censusdata";
-  import GeodataApiDataService from "../../../model/censusdata/services/geodataApiDataService";
-  import { mapBBoxCodes } from "../../../model/censusdata/stores";
 
   import { page } from "$app/stores";
   import { onMount } from "svelte";
-  import { mapZoomBBox } from "../../../model/geography/stores";
 
   let { topicSlug, tableSlug, categorySlug } = $page.params;
   let category = null;
@@ -60,23 +47,6 @@
   let locationId = null;
   let locationName = "";
   locationId = $page.query.get("location");
-
-  // $: if ($mapZoomBBox) {
-  //   fetchSelectedDataForWholeBoundingBox(new GeodataApiDataService(), ['LSOA'], ["QS802EW0001"], $mapZoomBBox)
-  // }
-
-  $: console.log("selectedGeographyData", $selectedGeographyData);
-
-  setTimeout(() => {
-    fetchAllDataForGeography(new GeodataApiDataService(), "W06000023");
-  }, 4000);
-
-  // $: $newDataByGeography, console.log("NEW dataByGeography", $dataByGeography);
-
-  // $: if ($mapBBoxCodes){
-  //   console.log($mapBBoxCodes)
-  //   fetchSelectedDataForNewBoundingBoxGeographies(new GeodataApiDataService(), ["QS802EW0001"]);
-  // }
 
   onMount(async () => {
     if (locationId) {

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -16,19 +16,10 @@
   import { indexPageSuggestions } from "../config.js";
   import { reverseLadLookup } from "../model/geography/geography";
   import { goto } from "$app/navigation";
-  import { fetchSelectedDataForGeographies, mapGeographyData } from "../model/censusdata/censusdata";
-  import GeodataApiDataService from "../model/censusdata/services/geodataApiDataService";
-
+ 
   let autosuggestData = "https://raw.githubusercontent.com/ONSdigital/census-atlas/master/src/data/ladList.json";
   let englandWalesBounds = [2.08, 55.68, -6.59, 48.53];
   let userInputValue;
-
-  // fetchSelectedDataForGeographies(
-  //   new GeodataApiDataService(),
-  //   ["E06000001", "E06000002", "E06000003"],
-  //   ["QS802EW0001", "QS802EW0004", "QS802EW0005"],
-  // );
-  // $: console.log("mapGeographyData", $mapGeographyData);
 
   function submitFunction(ladInput) {
     if (reverseLadLookup[ladInput]) {

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -16,17 +16,19 @@
   import { indexPageSuggestions } from "../config.js";
   import { reverseLadLookup } from "../model/geography/geography";
   import { goto } from "$app/navigation";
-  import {fetchSelectedDataForGeoType, mapGeographyData} from "../model/censusdata/censusdata"
-  import GeodataApiDataService from "../model/censusdata/services/geodataApiDataService"
-
+  import { fetchSelectedDataForGeographies, mapGeographyData } from "../model/censusdata/censusdata";
+  import GeodataApiDataService from "../model/censusdata/services/geodataApiDataService";
 
   let autosuggestData = "https://raw.githubusercontent.com/ONSdigital/census-atlas/master/src/data/ladList.json";
   let englandWalesBounds = [2.08, 55.68, -6.59, 48.53];
   let userInputValue;
-  
-  fetchSelectedDataForGeoType(new GeodataApiDataService(), "lad", ["QS802EW0007", "QS802EW0006","QS802EW0005"])
-  $: console.log($mapGeographyData)
 
+  fetchSelectedDataForGeographies(
+    new GeodataApiDataService(),
+    ["E06000001", "E06000002", "E06000003"],
+    ["QS802EW0001", "QS802EW0004", "QS802EW0005"],
+  );
+  $: console.log($mapGeographyData);
 
   function submitFunction(ladInput) {
     if (reverseLadLookup[ladInput]) {

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -16,10 +16,17 @@
   import { indexPageSuggestions } from "../config.js";
   import { reverseLadLookup } from "../model/geography/geography";
   import { goto } from "$app/navigation";
+  import {fetchSelectedDataForGeoType, mapGeographyData} from "../model/censusdata/censusdata"
+  import GeodataApiDataService from "../model/censusdata/services/geodataApiDataService"
+
 
   let autosuggestData = "https://raw.githubusercontent.com/ONSdigital/census-atlas/master/src/data/ladList.json";
   let englandWalesBounds = [2.08, 55.68, -6.59, 48.53];
   let userInputValue;
+  
+  fetchSelectedDataForGeoType(new GeodataApiDataService(), "lad", ["QS802EW0007", "QS802EW0006","QS802EW0005"])
+  $: console.log($mapGeographyData)
+
 
   function submitFunction(ladInput) {
     if (reverseLadLookup[ladInput]) {

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -16,7 +16,7 @@
   import { indexPageSuggestions } from "../config.js";
   import { reverseLadLookup } from "../model/geography/geography";
   import { goto } from "$app/navigation";
- 
+
   let autosuggestData = "https://raw.githubusercontent.com/ONSdigital/census-atlas/master/src/data/ladList.json";
   let englandWalesBounds = [2.08, 55.68, -6.59, 48.53];
   let userInputValue;

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -23,12 +23,12 @@
   let englandWalesBounds = [2.08, 55.68, -6.59, 48.53];
   let userInputValue;
 
-  fetchSelectedDataForGeographies(
-    new GeodataApiDataService(),
-    ["E06000001", "E06000002", "E06000003"],
-    ["QS802EW0001", "QS802EW0004", "QS802EW0005"],
-  );
-  $: console.log($mapGeographyData);
+  // fetchSelectedDataForGeographies(
+  //   new GeodataApiDataService(),
+  //   ["E06000001", "E06000002", "E06000003"],
+  //   ["QS802EW0001", "QS802EW0004", "QS802EW0005"],
+  // );
+  // $: console.log("mapGeographyData", $mapGeographyData);
 
   function submitFunction(ladInput) {
     if (reverseLadLookup[ladInput]) {

--- a/src/ui/map/InteractiveLayer.svelte
+++ b/src/ui/map/InteractiveLayer.svelte
@@ -152,8 +152,6 @@
       }
     });
 
-
-
     map.on("mouseleave", id, (e) => {
       if (hovered) {
         map.setFeatureState({ source: source, sourceLayer: sourceLayer, id: hovered }, { hovered: false });

--- a/src/ui/map/InteractiveLayer.svelte
+++ b/src/ui/map/InteractiveLayer.svelte
@@ -1,6 +1,5 @@
 <script>
-  import { getContext } from "svelte";
-  import { createEventDispatcher } from "svelte";
+  import { getContext, createEventDispatcher } from "svelte";
   import config from "./../../config";
 
   const dispatch = createEventDispatcher();
@@ -152,6 +151,8 @@
         map.getCanvas().style.cursor = "pointer";
       }
     });
+
+
 
     map.on("mouseleave", id, (e) => {
       if (hovered) {

--- a/src/ui/map/Map.svelte
+++ b/src/ui/map/Map.svelte
@@ -21,8 +21,8 @@
 
   let container;
 
-  $: if ($mapZoomBBox){
-    mapBBoxCodes.set(getMapBBoxGeoCodes(map))
+  $: if ($mapZoomBBox) {
+    mapBBoxCodes.set(getMapBBoxGeoCodes(map));
   }
   $: {
     if (map && $selectedGeography.lad && ladBoundsLookup[$selectedGeography.lad]) {

--- a/src/ui/map/Map.svelte
+++ b/src/ui/map/Map.svelte
@@ -4,6 +4,9 @@
   import mapstyle from "./../../data/mapstyle";
   import { selectedGeography } from "../../model/geography/geography";
   import ladBoundsLookup from "../../data/ladMapBoundsLookup";
+  import {writable} from "svelte/store"
+
+  export let mapBbox = writable([])
 
   export let map = null;
   export let minzoom = 0;
@@ -11,6 +14,7 @@
 
   export let bounds = [3.2, 55.17, -6.17, 50.38];
   export let zoom = 6;
+
 
   let options = {
     bounds: bounds,
@@ -61,6 +65,12 @@
       map.on("zoom", () => {
         zoom = map.getZoom();
       });
+
+      map.on('drag', () => {    
+        const bBoxCodes = map.queryRenderedFeatures({layers: ['lad-interactive-layer', 'lsoa-boundaries']}).map(feature => feature.id)
+        const filteredCodes = [...new Set(bBoxCodes)];
+        mapBbox.set(filteredCodes)
+})
     };
 
     document.head.appendChild(link);

--- a/src/ui/map/Map.svelte
+++ b/src/ui/map/Map.svelte
@@ -4,9 +4,9 @@
   import mapstyle from "./../../data/mapstyle";
   import { selectedGeography } from "../../model/geography/geography";
   import ladBoundsLookup from "../../data/ladMapBoundsLookup";
-  import {writable} from "svelte/store"
+  import { writable } from "svelte/store";
 
-  export let mapBbox = writable([])
+  export let mapBbox = writable([]);
 
   export let map = null;
   export let minzoom = 0;
@@ -14,7 +14,6 @@
 
   export let bounds = [3.2, 55.17, -6.17, 50.38];
   export let zoom = 6;
-
 
   let options = {
     bounds: bounds,
@@ -66,11 +65,13 @@
         zoom = map.getZoom();
       });
 
-      map.on('drag', () => {    
-        const bBoxCodes = map.queryRenderedFeatures({layers: ['lad-interactive-layer', 'lsoa-boundaries']}).map(feature => feature.id)
+      map.on("drag", () => {
+        const bBoxCodes = map
+          .queryRenderedFeatures({ layers: ["lad-interactive-layer", "lsoa-boundaries"] })
+          .map((feature) => feature.id);
         const filteredCodes = [...new Set(bBoxCodes)];
-        mapBbox.set(filteredCodes)
-})
+        mapBbox.set(filteredCodes);
+      });
     };
 
     document.head.appendChild(link);

--- a/src/ui/map/Map.svelte
+++ b/src/ui/map/Map.svelte
@@ -2,9 +2,9 @@
   import { onMount, setContext } from "svelte";
   import { Map, NavigationControl } from "mapbox-gl";
   import mapstyle from "./../../data/mapstyle";
-  import { selectedGeography, setMapBBoxGeoCodes } from "../../model/geography/geography";
+  import { selectedGeography, getMapBBoxGeoCodes } from "../../model/geography/geography";
   import ladBoundsLookup from "../../data/ladMapBoundsLookup";
-  import { mapBboxCodes } from "../../model/censusdata/stores";
+  import { mapBBoxCodes } from "../../model/censusdata/stores";
   import { mapZoomBBox } from "../../model/geography/stores";
 
   export let map = null;
@@ -21,8 +21,9 @@
 
   let container;
 
-  $: mapZoomBBox, setMapBBoxGeoCodes(map, $mapBboxCodes);
-
+  $: if ($mapZoomBBox){
+    mapBBoxCodes.set(getMapBBoxGeoCodes(map))
+  }
   $: {
     if (map && $selectedGeography.lad && ladBoundsLookup[$selectedGeography.lad]) {
       bounds = [


### PR DESCRIPTION
Valentina and I have set up a Geodata API data service, with functionality for four types of fetch requests.

We have created two stores for the data: selectedGeographyData, to store data about the currently selected geography, and dataByGeography, which will store data for multiple geographies.  Both stores are Maps, so that data can be stored as key value pairs whilst allowing us to optimise checking for existing data.

We also created a boolean store, newDataByGeography, to work around some issues with reactivity in Svelte.  Because Svelte doesn't always update objects and arrays based on changes made via methods (see https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Svelte_reactivity_lifecycle_accessibility), newDataByGeography can be used as in lines 75-76 to notify components that dataByGeography has been updated.

![Screenshot 2021-12-20 at 16 14 57](https://user-images.githubusercontent.com/70749355/146798362-250222d9-a780-40d3-be20-f476c8af42a8.png)

We also implemented Viv's debounce function for setting the bounding box as the user drags around the map. 

