### PR TITLE
Feature/refactors api data service

### DIFF
--- a/src/model/censusdata/censusdata.js
+++ b/src/model/censusdata/censusdata.js
@@ -44,16 +44,32 @@ export async function fetchAllDataForGeography(censusDataService, geographyCode)
   selectedGeographyData.set(data);
 }
 
-export async function fetchSelectedDataForGeoType(censusDataService, geoType, categories) {
+export async function fetchSelectedDataForGeoType(censusDataService, geoType, categories, overwriteCache) {
   dataService = censusDataService;
   const data = await dataService.fetchSelectedDataForGeographyType(geoType, categories);
-  dataByGeography.set(data);
+  if (overwriteCache){
+    dataByGeography.set(data);
+  } else {
+    data.forEach((data, key) => {
+      const catCode = Object.keys(data);
+      get(dataByGeography).set(key, { [catCode]: data[catCode] });
+    });
+    newDataByGeography.notify()
+  }
 }
 
-export async function fetchSelectedDataForGeographies(censusDataService, geoCodes, catCodes) {
+export async function fetchSelectedDataForGeographies(censusDataService, geoCodes, catCodes, overwriteCache) {
   dataService = censusDataService;
   const data = await dataService.fetchSelectedDataForGeographies(geoCodes, catCodes);
-  dataByGeography.set(data);
+  if (overwriteCache){
+    dataByGeography.set(data);
+  } else {
+    data.forEach((data, key) => {
+      const catCode = Object.keys(data);
+      get(dataByGeography).set(key, { [catCode]: data[catCode] });
+    });
+    newDataByGeography.notify()
+  }
 }
 
 function filterOutMapBBoxCodesWithCachedData(dataByGeography, mapBBoxCodes) {
@@ -63,22 +79,33 @@ function filterOutMapBBoxCodesWithCachedData(dataByGeography, mapBBoxCodes) {
   return mapBBoxCodes.filter((item) => !dataByGeography.has(item));
 }
 
-export async function fetchSelectedDataForNewBoundingBoxGeographies(censusDataService, catCodes) {
+export async function fetchSelectedDataForNewBoundingBoxGeographies(censusDataService, catCodes, overwriteCache) {
   dataService = censusDataService;
   const geoCodes = filterOutMapBBoxCodesWithCachedData(get(dataByGeography), get(mapBBoxCodes));
   const data = await dataService.fetchSelectedDataForGeographies(geoCodes, catCodes);
-  data.forEach((data, key) => {
-    const catCode = Object.keys(data);
-    get(dataByGeography).set(key, { [catCode]: data[catCode] });
-  });
-  //temporarily sets store to true to so components can listen for new data
-  newDataByGeography.notify()
+  if (overwriteCache){
+    dataByGeography.set(data);
+  } else {
+    data.forEach((data, key) => {
+      const catCode = Object.keys(data);
+      get(dataByGeography).set(key, { [catCode]: data[catCode] });
+    });
+    newDataByGeography.notify()
+  }
 }
 
-export async function fetchSelectedDataForWholeBoundingBox(censusDataService, geoTypes, catCodes, bBox) {
+export async function fetchSelectedDataForWholeBoundingBox(censusDataService, geoTypes, catCodes, bBox, overwriteCache) {
   dataService = censusDataService;
   const data = await dataService.fetchSelectedDataForBoundingBox(geoTypes, catCodes, bBox);
-  dataByGeography.set(data);
+  if (overwriteCache){
+    dataByGeography.set(data);
+  } else {
+    data.forEach((data, key) => {
+      const catCode = Object.keys(data);
+      get(dataByGeography).set(key, { [catCode]: data[catCode] });
+    });
+    newDataByGeography.notify()
+  }
 }
 
 export async function initialiseCensusData(censusDataService) {

--- a/src/model/censusdata/censusdata.js
+++ b/src/model/censusdata/censusdata.js
@@ -1,5 +1,6 @@
 import { writable, get } from "svelte/store";
 import { mapBBoxCodes, toggleable } from "./stores";
+import {addNewGeoDataToCache} from "../utils"
 
 export let selectedGeographyData = writable(new Map());
 export let dataByGeography = writable(new Map());
@@ -50,11 +51,7 @@ export async function fetchSelectedDataForGeoType(censusDataService, geoType, ca
   if (overwriteCache){
     dataByGeography.set(data);
   } else {
-    data.forEach((data, key) => {
-      const catCode = Object.keys(data);
-      get(dataByGeography).set(key, { [catCode]: data[catCode] });
-    });
-    newDataByGeography.notify()
+    addNewGeoDataToCache(data)
   }
 }
 
@@ -64,11 +61,7 @@ export async function fetchSelectedDataForGeographies(censusDataService, geoCode
   if (overwriteCache){
     dataByGeography.set(data);
   } else {
-    data.forEach((data, key) => {
-      const catCode = Object.keys(data);
-      get(dataByGeography).set(key, { [catCode]: data[catCode] });
-    });
-    newDataByGeography.notify()
+    addNewGeoDataToCache(data)
   }
 }
 
@@ -86,11 +79,7 @@ export async function fetchSelectedDataForNewBoundingBoxGeographies(censusDataSe
   if (overwriteCache){
     dataByGeography.set(data);
   } else {
-    data.forEach((data, key) => {
-      const catCode = Object.keys(data);
-      get(dataByGeography).set(key, { [catCode]: data[catCode] });
-    });
-    newDataByGeography.notify()
+    addNewGeoDataToCache(data)
   }
 }
 
@@ -100,11 +89,7 @@ export async function fetchSelectedDataForWholeBoundingBox(censusDataService, ge
   if (overwriteCache){
     dataByGeography.set(data);
   } else {
-    data.forEach((data, key) => {
-      const catCode = Object.keys(data);
-      get(dataByGeography).set(key, { [catCode]: data[catCode] });
-    });
-    newDataByGeography.notify()
+    addNewGeoDataToCache(data)
   }
 }
 

--- a/src/model/utils.js
+++ b/src/model/utils.js
@@ -1,4 +1,6 @@
 import { csvParse } from "d3-dsv";
+import { dataByGeography, newDataByGeography } from "./censusdata/censusdata";
+import { get } from "svelte/store";
 
 export function getLegendSection(value, breakpoints) {
   for (let i = 1; i < breakpoints.length; i++) {
@@ -21,4 +23,16 @@ export function writeDataToMapObj(responseStr) {
     data.set(row.geography_code, geoDataObject);
   });
   return data;
+}
+
+export function addNewGeoDataToCache(data){
+  data.forEach((data, key) => {
+    let catDataObj = {}
+    const catCodes = Object.keys(data);
+    catCodes.forEach((catCode) => {
+      catDataObj[catCode] = data[catCode]
+    })
+    get(dataByGeography).set(key, catDataObj);
+  });
+  newDataByGeography.notify()
 }

--- a/src/model/utils.js
+++ b/src/model/utils.js
@@ -32,7 +32,15 @@ export function addNewGeoDataToCache(data){
     catCodes.forEach((catCode) => {
       catDataObj[catCode] = data[catCode]
     })
-    get(dataByGeography).set(key, catDataObj);
+    //if cache already contains category data for given geography...
+    if (get(dataByGeography).has(key)){
+      //add new category data to existing data for given geography
+      const cachedGeoData = get(dataByGeography).get(key)
+      get(dataByGeography).set(key, {...cachedGeoData, ...catDataObj})
+    } else {
+      //otherwise add new geography & data to store
+      get(dataByGeography).set(key, catDataObj);
+    }
   });
   newDataByGeography.notify()
 }


### PR DESCRIPTION
I have refactored the censusData.js functions to allow them to add new data to existing cached data without overwriting the data in the store.  This option is controlled via the overwriteCache argument.

I have also modified these functions so that if 1) overwriteCache is not true and 2) there is existing category data in the store for a given geography, new category data will be added to the existing category data rather than overwriting it.  I guess we may need to think about whether we also want to have both options at this level, and if so what would be the cleanest way to achieve it.