### PR TITLE
update endpoint URLS for querying dp-geodata-api

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -28,8 +28,8 @@ export default {
   },
   api: {
     baseUrl: "https://cep5lmkia0.execute-api.eu-west-1.amazonaws.com/dev/",
-    censusMetadataEndpoint: "metadata",
-    censusDataEndpoint: "dev/hello/census",
+    censusMetadataEndpoint: "metadata/2011",
+    censusDataEndpoint: "query/2011",
   },
   ux: {
     legend_sections: 5,


### PR DESCRIPTION
Update URLS for dp-geodata-api to match new ones merged [here](https://github.com/ONSdigital/dp-find-insights-poc-api/pull/166). This will be needed to merge once the new API is deployed.