### PR TITLE
Feature/comparison component

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -3,8 +3,6 @@ module.exports = {
     "^.+\\.svelte$": "svelte-jester",
     "^.+\\.js$": "babel-jest",
   },
-  transformIgnorePatterns: [
-    "node_modules/(?!@ngrx|(?!deck.gl)|ng-dynamic)"
-  ],
+  transformIgnorePatterns: ["node_modules/(?!@ngrx|(?!deck.gl)|ng-dynamic)"],
   moduleFileExtensions: ["js", "svelte"],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -4545,13 +4545,9 @@
       }
     },
     "node_modules/core-js-pure": {
-<<<<<<< HEAD
-      "version": "3.19.2",
-=======
       "version": "3.20.3",
       "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.20.3.tgz",
       "integrity": "sha512-Q2H6tQ5MtPtcC7f3HxJ48i4Q7T9ybPKgvWyuH7JXIoNa2pm0KuBnycsET/qw1SLLZYfbsbrZQNMeIOClb+6WIA==",
->>>>>>> add some example tests for components
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/src/config.js
+++ b/src/config.js
@@ -83,6 +83,7 @@ export default {
     text: "Not a valid search",
   },
   autosuggestData: "https://raw.githubusercontent.com/ONSdigital/census-atlas/master/src/data/ladList.json",
+  eAndWGeoCode: "K04000001",
 };
 
 export const indexPageSuggestions = [

--- a/src/data/apiMetadata.js
+++ b/src/data/apiMetadata.js
@@ -1,3187 +1,3187 @@
 export default [
   {
-      "code": "Education",
-      "name": "Education",
-      "slug": "education",
-      "desc": "Residents in education and qualifications they hold.",
-      "tables": [
+    code: "Education",
+    name: "Education",
+    slug: "education",
+    desc: "Residents in education and qualifications they hold.",
+    tables: [
+      {
+        categories: [
           {
-              "categories": [
-                  {
-                      "code": "QS501EW0002",
-                      "name": "No qualifications",
-                      "slug": "no-qualifications"
-                  },
-                  {
-                      "code": "QS501EW0003",
-                      "name": "Level 1 qualifications",
-                      "slug": "level-1-qualifications"
-                  },
-                  {
-                      "code": "QS501EW0004",
-                      "name": "Level 2 qualifications",
-                      "slug": "level-2-qualifications"
-                  },
-                  {
-                      "code": "QS501EW0005",
-                      "name": "Apprenticeship",
-                      "slug": "apprenticeship"
-                  },
-                  {
-                      "code": "QS501EW0006",
-                      "name": "Level 3 qualifications",
-                      "slug": "level-3-qualifications"
-                  },
-                  {
-                      "code": "QS501EW0007",
-                      "name": "Level 4 qualifications and above",
-                      "slug": "level-4-qualifications-and-above"
-                  },
-                  {
-                      "code": "QS501EW0008",
-                      "name": "Other qualifications",
-                      "slug": "other-qualifications"
-                  }
-              ],
-              "code": "QS501EW",
-              "name": "Highest level of qualification gained",
-              "slug": "highest-level-of-qualification-gained",
-              "desc": "Highest qualification gained by residents.",
-              "total": {
-                  "code": "QS501EW0001",
-                  "name": "All categories: Highest level of qualification",
-                  "slug": "all-categories-highest-level-of-qualification"
-              },
-              "units": "People (usual residents)"
-          }
-      ]
+            code: "QS501EW0002",
+            name: "No qualifications",
+            slug: "no-qualifications",
+          },
+          {
+            code: "QS501EW0003",
+            name: "Level 1 qualifications",
+            slug: "level-1-qualifications",
+          },
+          {
+            code: "QS501EW0004",
+            name: "Level 2 qualifications",
+            slug: "level-2-qualifications",
+          },
+          {
+            code: "QS501EW0005",
+            name: "Apprenticeship",
+            slug: "apprenticeship",
+          },
+          {
+            code: "QS501EW0006",
+            name: "Level 3 qualifications",
+            slug: "level-3-qualifications",
+          },
+          {
+            code: "QS501EW0007",
+            name: "Level 4 qualifications and above",
+            slug: "level-4-qualifications-and-above",
+          },
+          {
+            code: "QS501EW0008",
+            name: "Other qualifications",
+            slug: "other-qualifications",
+          },
+        ],
+        code: "QS501EW",
+        name: "Highest level of qualification gained",
+        slug: "highest-level-of-qualification-gained",
+        desc: "Highest qualification gained by residents.",
+        total: {
+          code: "QS501EW0001",
+          name: "All categories: Highest level of qualification",
+          slug: "all-categories-highest-level-of-qualification",
+        },
+        units: "People (usual residents)",
+      },
+    ],
   },
   {
-      "code": "Health",
-      "name": "Health",
-      "slug": "health",
-      "desc": "General health and caring responsibilities.",
-      "tables": [
+    code: "Health",
+    name: "Health",
+    slug: "health",
+    desc: "General health and caring responsibilities.",
+    tables: [
+      {
+        categories: [
           {
-              "categories": [
-                  {
-                      "code": "QS302EW0002",
-                      "name": "Very good health",
-                      "slug": "very-good-health"
-                  },
-                  {
-                      "code": "QS302EW0003",
-                      "name": "Good health",
-                      "slug": "good-health"
-                  },
-                  {
-                      "code": "QS302EW0004",
-                      "name": "Fair health",
-                      "slug": "fair-health"
-                  },
-                  {
-                      "code": "QS302EW0005",
-                      "name": "Bad health",
-                      "slug": "bad-health"
-                  },
-                  {
-                      "code": "QS302EW0006",
-                      "name": "Very bad health",
-                      "slug": "very-bad-health"
-                  }
-              ],
-              "code": "QS302EW",
-              "name": "General health",
-              "slug": "general-health",
-              "desc": "How people rate their general health.",
-              "total": {
-                  "code": "QS302EW0001",
-                  "name": "All categories: General health",
-                  "slug": "all-categories-general-health"
-              },
-              "units": "People (usual residents)"
+            code: "QS302EW0002",
+            name: "Very good health",
+            slug: "very-good-health",
           },
           {
-              "categories": [
-                  {
-                      "code": "QS303EW0002",
-                      "name": "Day-to-day activities limited a lot",
-                      "slug": "day-to-day-activities-limited-a-lot"
-                  },
-                  {
-                      "code": "QS303EW0003",
-                      "name": "Day-to-day activities limited a little",
-                      "slug": "day-to-day-activities-limited-a-little"
-                  },
-                  {
-                      "code": "QS303EW0004",
-                      "name": "Day-to-day activities not limited",
-                      "slug": "day-to-day-activities-not-limited"
-                  }
-              ],
-              "code": "QS303EW",
-              "name": "Long-term health problem or disability",
-              "slug": "long-term-health-problem-or-disability",
-              "desc": "How people's heath affect their day-to-day activities.",
-              "total": {
-                  "code": "QS303EW0001",
-                  "name": "All categories: Long-term health problem or disability",
-                  "slug": "all-categories-long-term-health-problem-or-disability"
-              },
-              "units": "People (usual residents)"
+            code: "QS302EW0003",
+            name: "Good health",
+            slug: "good-health",
           },
           {
-              "categories": [
-                  {
-                      "code": "QS301EW0002",
-                      "name": "Provides no unpaid care",
-                      "slug": "provides-no-unpaid-care"
-                  },
-                  {
-                      "code": "QS301EW0003",
-                      "name": "Provides 1 to 19 hours unpaid care a week",
-                      "slug": "provides-1-to-19-hours-unpaid-care-a-week"
-                  },
-                  {
-                      "code": "QS301EW0004",
-                      "name": "Provides 20 to 49 hours unpaid care a week",
-                      "slug": "provides-20-to-49-hours-unpaid-care-a-week"
-                  },
-                  {
-                      "code": "QS301EW0005",
-                      "name": "Provides 50 or more hours unpaid care a week",
-                      "slug": "provides-50-or-more-hours-unpaid-care-a-week"
-                  }
-              ],
-              "code": "QS301EW",
-              "name": "Unpaid care ",
-              "slug": "unpaid-care",
-              "desc": "People who provide unpaid care.",
-              "total": {
-                  "code": "QS301EW0001",
-                  "name": "All categories: Provision of unpaid care",
-                  "slug": "all-categories-provision-of-unpaid-care"
-              },
-              "units": "People (usual residents)"
-          }
-      ]
+            code: "QS302EW0004",
+            name: "Fair health",
+            slug: "fair-health",
+          },
+          {
+            code: "QS302EW0005",
+            name: "Bad health",
+            slug: "bad-health",
+          },
+          {
+            code: "QS302EW0006",
+            name: "Very bad health",
+            slug: "very-bad-health",
+          },
+        ],
+        code: "QS302EW",
+        name: "General health",
+        slug: "general-health",
+        desc: "How people rate their general health.",
+        total: {
+          code: "QS302EW0001",
+          name: "All categories: General health",
+          slug: "all-categories-general-health",
+        },
+        units: "People (usual residents)",
+      },
+      {
+        categories: [
+          {
+            code: "QS303EW0002",
+            name: "Day-to-day activities limited a lot",
+            slug: "day-to-day-activities-limited-a-lot",
+          },
+          {
+            code: "QS303EW0003",
+            name: "Day-to-day activities limited a little",
+            slug: "day-to-day-activities-limited-a-little",
+          },
+          {
+            code: "QS303EW0004",
+            name: "Day-to-day activities not limited",
+            slug: "day-to-day-activities-not-limited",
+          },
+        ],
+        code: "QS303EW",
+        name: "Long-term health problem or disability",
+        slug: "long-term-health-problem-or-disability",
+        desc: "How people's heath affect their day-to-day activities.",
+        total: {
+          code: "QS303EW0001",
+          name: "All categories: Long-term health problem or disability",
+          slug: "all-categories-long-term-health-problem-or-disability",
+        },
+        units: "People (usual residents)",
+      },
+      {
+        categories: [
+          {
+            code: "QS301EW0002",
+            name: "Provides no unpaid care",
+            slug: "provides-no-unpaid-care",
+          },
+          {
+            code: "QS301EW0003",
+            name: "Provides 1 to 19 hours unpaid care a week",
+            slug: "provides-1-to-19-hours-unpaid-care-a-week",
+          },
+          {
+            code: "QS301EW0004",
+            name: "Provides 20 to 49 hours unpaid care a week",
+            slug: "provides-20-to-49-hours-unpaid-care-a-week",
+          },
+          {
+            code: "QS301EW0005",
+            name: "Provides 50 or more hours unpaid care a week",
+            slug: "provides-50-or-more-hours-unpaid-care-a-week",
+          },
+        ],
+        code: "QS301EW",
+        name: "Unpaid care ",
+        slug: "unpaid-care",
+        desc: "People who provide unpaid care.",
+        total: {
+          code: "QS301EW0001",
+          name: "All categories: Provision of unpaid care",
+          slug: "all-categories-provision-of-unpaid-care",
+        },
+        units: "People (usual residents)",
+      },
+    ],
   },
   {
-      "code": "Housing",
-      "name": "Housing",
-      "slug": "housing",
-      "desc": "Types of homes and the people living in them.",
-      "tables": [
+    code: "Housing",
+    name: "Housing",
+    slug: "housing",
+    desc: "Types of homes and the people living in them.",
+    tables: [
+      {
+        categories: [
           {
-              "categories": [
-                  {
-                      "code": "QS406EW0002",
-                      "name": "1 person in household",
-                      "slug": "1-person-in-household"
-                  },
-                  {
-                      "code": "QS406EW0003",
-                      "name": "2 people in household",
-                      "slug": "2-people-in-household"
-                  },
-                  {
-                      "code": "QS406EW0004",
-                      "name": "3 people in household",
-                      "slug": "3-people-in-household"
-                  },
-                  {
-                      "code": "QS406EW0005",
-                      "name": "4 people in household",
-                      "slug": "4-people-in-household"
-                  },
-                  {
-                      "code": "QS406EW0006",
-                      "name": "5 people in household",
-                      "slug": "5-people-in-household"
-                  },
-                  {
-                      "code": "QS406EW0007",
-                      "name": "6 people in household",
-                      "slug": "6-people-in-household"
-                  },
-                  {
-                      "code": "QS406EW0008",
-                      "name": "7 people in household",
-                      "slug": "7-people-in-household"
-                  },
-                  {
-                      "code": "QS406EW0009",
-                      "name": "8 or more people in household",
-                      "slug": "8-or-more-people-in-household"
-                  }
-              ],
-              "code": "QS406EW",
-              "name": "Size of household",
-              "slug": "size-of-household",
-              "desc": "How many people living in the same home.",
-              "total": {
-                  "code": "QS406EW0001",
-                  "name": "All categories: Household size",
-                  "slug": "all-categories-household-size"
-              },
-              "units": "Households"
+            code: "QS406EW0002",
+            name: "1 person in household",
+            slug: "1-person-in-household",
           },
           {
-              "categories": [
-                  {
-                      "code": "QS402EW0002",
-                      "name": "Unshared dwelling: Total",
-                      "slug": "unshared-dwelling-total"
-                  },
-                  {
-                      "code": "QS402EW0003",
-                      "name": "Unshared dwelling: Whole house or bungalow: Total",
-                      "slug": "unshared-dwelling-whole-house-or-bungalow-total"
-                  },
-                  {
-                      "code": "QS402EW0004",
-                      "name": "Unshared dwelling: Whole house or bungalow: Detached",
-                      "slug": "unshared-dwelling-whole-house-or-bungalow-detached"
-                  },
-                  {
-                      "code": "QS402EW0005",
-                      "name": "Unshared dwelling: Whole house or bungalow: Semi-detached",
-                      "slug": "unshared-dwelling-whole-house-or-bungalow-semi-detached"
-                  },
-                  {
-                      "code": "QS402EW0006",
-                      "name": "Unshared dwelling: Whole house or bungalow: Terraced (including end-terrace)",
-                      "slug": "unshared-dwelling-whole-house-or-bungalow-terraced-including-end-terrace"
-                  },
-                  {
-                      "code": "QS402EW0007",
-                      "name": "Unshared dwelling: Flat, maisonette or apartment: Total",
-                      "slug": "unshared-dwelling-flat-maisonette-or-apartment-total"
-                  },
-                  {
-                      "code": "QS402EW0008",
-                      "name": "Unshared dwelling: Flat, maisonette or apartment: Purpose-built block of flats or tenement",
-                      "slug": "unshared-dwelling-flat-maisonette-or-apartment-purpose-built-block-of-flats-or-tenement"
-                  },
-                  {
-                      "code": "QS402EW0009",
-                      "name": "Unshared dwelling: Flat, maisonette or apartment: Part of a converted or shared house (including bed-sits)",
-                      "slug": "unshared-dwelling-flat-maisonette-or-apartment-part-of-a-converted-or-shared-house-including-bed-sits"
-                  },
-                  {
-                      "code": "QS402EW0010",
-                      "name": "Unshared dwelling: Flat, maisonette or apartment: In commercial building",
-                      "slug": "unshared-dwelling-flat-maisonette-or-apartment-in-commercial-building"
-                  },
-                  {
-                      "code": "QS402EW0011",
-                      "name": "Unshared dwelling: Caravan or other mobile or temporary structure",
-                      "slug": "unshared-dwelling-caravan-or-other-mobile-or-temporary-structure"
-                  },
-                  {
-                      "code": "QS402EW0012",
-                      "name": "Shared dwelling",
-                      "slug": "shared-dwelling"
-                  }
-              ],
-              "code": "QS402EW",
-              "name": "Type of home",
-              "slug": "type-of-home",
-              "desc": "Types of homes people live in.",
-              "total": {
-                  "code": "QS402EW0001",
-                  "name": "All categories: Accommodation type",
-                  "slug": "all-categories-accommodation-type"
-              },
-              "units": "Households"
+            code: "QS406EW0003",
+            name: "2 people in household",
+            slug: "2-people-in-household",
           },
           {
-              "categories": [
-                  {
-                      "code": "QS411EW0002",
-                      "name": "No bedrooms",
-                      "slug": "no-bedrooms"
-                  },
-                  {
-                      "code": "QS411EW0003",
-                      "name": "1 bedroom",
-                      "slug": "1-bedroom"
-                  },
-                  {
-                      "code": "QS411EW0004",
-                      "name": "2 bedrooms",
-                      "slug": "2-bedrooms"
-                  },
-                  {
-                      "code": "QS411EW0005",
-                      "name": "3 bedrooms",
-                      "slug": "3-bedrooms"
-                  },
-                  {
-                      "code": "QS411EW0006",
-                      "name": "4 bedrooms",
-                      "slug": "4-bedrooms"
-                  },
-                  {
-                      "code": "QS411EW0007",
-                      "name": "5 or more bedrooms",
-                      "slug": "5-or-more-bedrooms"
-                  }
-              ],
-              "code": "QS411EW",
-              "name": "Number of bedrooms",
-              "slug": "number-of-bedrooms",
-              "desc": "",
-              "total": {
-                  "code": "QS411EW0001",
-                  "name": "All categories: Number of bedrooms",
-                  "slug": "all-categories-number-of-bedrooms"
-              },
-              "units": "Households"
+            code: "QS406EW0004",
+            name: "3 people in household",
+            slug: "3-people-in-household",
           },
           {
-              "categories": [
-                  {
-                      "code": "QS402EW0002",
-                      "name": "Unshared dwelling: Total",
-                      "slug": "unshared-dwelling-total"
-                  },
-                  {
-                      "code": "QS402EW0003",
-                      "name": "Unshared dwelling: Whole house or bungalow: Total",
-                      "slug": "unshared-dwelling-whole-house-or-bungalow-total"
-                  },
-                  {
-                      "code": "QS402EW0004",
-                      "name": "Unshared dwelling: Whole house or bungalow: Detached",
-                      "slug": "unshared-dwelling-whole-house-or-bungalow-detached"
-                  },
-                  {
-                      "code": "QS402EW0005",
-                      "name": "Unshared dwelling: Whole house or bungalow: Semi-detached",
-                      "slug": "unshared-dwelling-whole-house-or-bungalow-semi-detached"
-                  },
-                  {
-                      "code": "QS402EW0006",
-                      "name": "Unshared dwelling: Whole house or bungalow: Terraced (including end-terrace)",
-                      "slug": "unshared-dwelling-whole-house-or-bungalow-terraced-including-end-terrace"
-                  },
-                  {
-                      "code": "QS402EW0007",
-                      "name": "Unshared dwelling: Flat, maisonette or apartment: Total",
-                      "slug": "unshared-dwelling-flat-maisonette-or-apartment-total"
-                  },
-                  {
-                      "code": "QS402EW0008",
-                      "name": "Unshared dwelling: Flat, maisonette or apartment: Purpose-built block of flats or tenement",
-                      "slug": "unshared-dwelling-flat-maisonette-or-apartment-purpose-built-block-of-flats-or-tenement"
-                  },
-                  {
-                      "code": "QS402EW0009",
-                      "name": "Unshared dwelling: Flat, maisonette or apartment: Part of a converted or shared house (including bed-sits)",
-                      "slug": "unshared-dwelling-flat-maisonette-or-apartment-part-of-a-converted-or-shared-house-including-bed-sits"
-                  },
-                  {
-                      "code": "QS402EW0010",
-                      "name": "Unshared dwelling: Flat, maisonette or apartment: In commercial building",
-                      "slug": "unshared-dwelling-flat-maisonette-or-apartment-in-commercial-building"
-                  },
-                  {
-                      "code": "QS402EW0011",
-                      "name": "Unshared dwelling: Caravan or other mobile or temporary structure",
-                      "slug": "unshared-dwelling-caravan-or-other-mobile-or-temporary-structure"
-                  },
-                  {
-                      "code": "QS402EW0012",
-                      "name": "Shared dwelling",
-                      "slug": "shared-dwelling"
-                  }
-              ],
-              "code": "QS402EW",
-              "name": "Owned and renting",
-              "slug": "owned-and-renting",
-              "desc": "People that live in a home they rent or own.",
-              "total": {
-                  "code": "QS402EW0001",
-                  "name": "All categories: Accommodation type",
-                  "slug": "all-categories-accommodation-type"
-              },
-              "units": "Households"
+            code: "QS406EW0005",
+            name: "4 people in household",
+            slug: "4-people-in-household",
           },
           {
-              "categories": [
-                  {
-                      "code": "QS416EW0002",
-                      "name": "No cars or vans in household",
-                      "slug": "no-cars-or-vans-in-household"
-                  },
-                  {
-                      "code": "QS416EW0003",
-                      "name": "1 car or van in household",
-                      "slug": "1-car-or-van-in-household"
-                  },
-                  {
-                      "code": "QS416EW0004",
-                      "name": "2 cars or vans in household",
-                      "slug": "2-cars-or-vans-in-household"
-                  },
-                  {
-                      "code": "QS416EW0005",
-                      "name": "3 cars or vans in household",
-                      "slug": "3-cars-or-vans-in-household"
-                  },
-                  {
-                      "code": "QS416EW0006",
-                      "name": "4 or more cars or vans in household",
-                      "slug": "4-or-more-cars-or-vans-in-household"
-                  },
-                  {
-                      "code": "QS416EW0007",
-                      "name": "All categories: Car or van availability",
-                      "slug": "all-categories-car-or-van-availability"
-                  }
-              ],
-              "code": "QS416EW",
-              "name": "Car or van availability",
-              "slug": "car-or-van-availability",
-              "desc": "People that have access to cars or vans.",
-              "total": {
-                  "code": "QS416EW0001",
-                  "name": "All categories: Car or van availability",
-                  "slug": "all-categories-car-or-van-availability"
-              },
-              "units": "Households"
+            code: "QS406EW0006",
+            name: "5 people in household",
+            slug: "5-people-in-household",
           },
           {
-              "categories": [
-                  {
-                      "code": "QS415EW0002",
-                      "name": "No central heating",
-                      "slug": "no-central-heating"
-                  },
-                  {
-                      "code": "QS415EW0003",
-                      "name": "Gas central heating",
-                      "slug": "gas-central-heating"
-                  },
-                  {
-                      "code": "QS415EW0004",
-                      "name": "Electric (including storage heaters) central heating",
-                      "slug": "electric-including-storage-heaters-central-heating"
-                  },
-                  {
-                      "code": "QS415EW0005",
-                      "name": "Oil central heating",
-                      "slug": "oil-central-heating"
-                  },
-                  {
-                      "code": "QS415EW0006",
-                      "name": "Solid fuel (for example wood, coal) central heating",
-                      "slug": "solid-fuel-for-example-wood-coal-central-heating"
-                  },
-                  {
-                      "code": "QS415EW0007",
-                      "name": "Other central heating",
-                      "slug": "other-central-heating"
-                  },
-                  {
-                      "code": "QS415EW0008",
-                      "name": "Two or more types of central heating",
-                      "slug": "two-or-more-types-of-central-heating"
-                  }
-              ],
-              "code": "QS415EW",
-              "name": "Heating",
-              "slug": "heating",
-              "desc": "Types of central heating",
-              "total": {
-                  "code": "QS415EW0001",
-                  "name": "All categories: Type of central heating in household",
-                  "slug": "all-categories-type-of-central-heating-in-household"
-              },
-              "units": "Households"
+            code: "QS406EW0007",
+            name: "6 people in household",
+            slug: "6-people-in-household",
           },
           {
-              "categories": [
-                  {
-                      "code": "QS106EW0002",
-                      "name": "No second address",
-                      "slug": "no-second-address"
-                  },
-                  {
-                      "code": "QS106EW0003",
-                      "name": "Second address within the UK",
-                      "slug": "second-address-within-the-uk"
-                  },
-                  {
-                      "code": "QS106EW0004",
-                      "name": "Second address outside the UK",
-                      "slug": "second-address-outside-the-uk"
-                  }
-              ],
-              "code": "QS106EW",
-              "name": "Second address",
-              "slug": "second-address",
-              "desc": "",
-              "total": {
-                  "code": "QS106EW0001",
-                  "name": "All categories: Second address",
-                  "slug": "all-categories-second-address"
-              },
-              "units": "People (usual residents)"
-          }
-      ]
+            code: "QS406EW0008",
+            name: "7 people in household",
+            slug: "7-people-in-household",
+          },
+          {
+            code: "QS406EW0009",
+            name: "8 or more people in household",
+            slug: "8-or-more-people-in-household",
+          },
+        ],
+        code: "QS406EW",
+        name: "Size of household",
+        slug: "size-of-household",
+        desc: "How many people living in the same home.",
+        total: {
+          code: "QS406EW0001",
+          name: "All categories: Household size",
+          slug: "all-categories-household-size",
+        },
+        units: "Households",
+      },
+      {
+        categories: [
+          {
+            code: "QS402EW0002",
+            name: "Unshared dwelling: Total",
+            slug: "unshared-dwelling-total",
+          },
+          {
+            code: "QS402EW0003",
+            name: "Unshared dwelling: Whole house or bungalow: Total",
+            slug: "unshared-dwelling-whole-house-or-bungalow-total",
+          },
+          {
+            code: "QS402EW0004",
+            name: "Unshared dwelling: Whole house or bungalow: Detached",
+            slug: "unshared-dwelling-whole-house-or-bungalow-detached",
+          },
+          {
+            code: "QS402EW0005",
+            name: "Unshared dwelling: Whole house or bungalow: Semi-detached",
+            slug: "unshared-dwelling-whole-house-or-bungalow-semi-detached",
+          },
+          {
+            code: "QS402EW0006",
+            name: "Unshared dwelling: Whole house or bungalow: Terraced (including end-terrace)",
+            slug: "unshared-dwelling-whole-house-or-bungalow-terraced-including-end-terrace",
+          },
+          {
+            code: "QS402EW0007",
+            name: "Unshared dwelling: Flat, maisonette or apartment: Total",
+            slug: "unshared-dwelling-flat-maisonette-or-apartment-total",
+          },
+          {
+            code: "QS402EW0008",
+            name: "Unshared dwelling: Flat, maisonette or apartment: Purpose-built block of flats or tenement",
+            slug: "unshared-dwelling-flat-maisonette-or-apartment-purpose-built-block-of-flats-or-tenement",
+          },
+          {
+            code: "QS402EW0009",
+            name: "Unshared dwelling: Flat, maisonette or apartment: Part of a converted or shared house (including bed-sits)",
+            slug: "unshared-dwelling-flat-maisonette-or-apartment-part-of-a-converted-or-shared-house-including-bed-sits",
+          },
+          {
+            code: "QS402EW0010",
+            name: "Unshared dwelling: Flat, maisonette or apartment: In commercial building",
+            slug: "unshared-dwelling-flat-maisonette-or-apartment-in-commercial-building",
+          },
+          {
+            code: "QS402EW0011",
+            name: "Unshared dwelling: Caravan or other mobile or temporary structure",
+            slug: "unshared-dwelling-caravan-or-other-mobile-or-temporary-structure",
+          },
+          {
+            code: "QS402EW0012",
+            name: "Shared dwelling",
+            slug: "shared-dwelling",
+          },
+        ],
+        code: "QS402EW",
+        name: "Type of home",
+        slug: "type-of-home",
+        desc: "Types of homes people live in.",
+        total: {
+          code: "QS402EW0001",
+          name: "All categories: Accommodation type",
+          slug: "all-categories-accommodation-type",
+        },
+        units: "Households",
+      },
+      {
+        categories: [
+          {
+            code: "QS411EW0002",
+            name: "No bedrooms",
+            slug: "no-bedrooms",
+          },
+          {
+            code: "QS411EW0003",
+            name: "1 bedroom",
+            slug: "1-bedroom",
+          },
+          {
+            code: "QS411EW0004",
+            name: "2 bedrooms",
+            slug: "2-bedrooms",
+          },
+          {
+            code: "QS411EW0005",
+            name: "3 bedrooms",
+            slug: "3-bedrooms",
+          },
+          {
+            code: "QS411EW0006",
+            name: "4 bedrooms",
+            slug: "4-bedrooms",
+          },
+          {
+            code: "QS411EW0007",
+            name: "5 or more bedrooms",
+            slug: "5-or-more-bedrooms",
+          },
+        ],
+        code: "QS411EW",
+        name: "Number of bedrooms",
+        slug: "number-of-bedrooms",
+        desc: "",
+        total: {
+          code: "QS411EW0001",
+          name: "All categories: Number of bedrooms",
+          slug: "all-categories-number-of-bedrooms",
+        },
+        units: "Households",
+      },
+      {
+        categories: [
+          {
+            code: "QS402EW0002",
+            name: "Unshared dwelling: Total",
+            slug: "unshared-dwelling-total",
+          },
+          {
+            code: "QS402EW0003",
+            name: "Unshared dwelling: Whole house or bungalow: Total",
+            slug: "unshared-dwelling-whole-house-or-bungalow-total",
+          },
+          {
+            code: "QS402EW0004",
+            name: "Unshared dwelling: Whole house or bungalow: Detached",
+            slug: "unshared-dwelling-whole-house-or-bungalow-detached",
+          },
+          {
+            code: "QS402EW0005",
+            name: "Unshared dwelling: Whole house or bungalow: Semi-detached",
+            slug: "unshared-dwelling-whole-house-or-bungalow-semi-detached",
+          },
+          {
+            code: "QS402EW0006",
+            name: "Unshared dwelling: Whole house or bungalow: Terraced (including end-terrace)",
+            slug: "unshared-dwelling-whole-house-or-bungalow-terraced-including-end-terrace",
+          },
+          {
+            code: "QS402EW0007",
+            name: "Unshared dwelling: Flat, maisonette or apartment: Total",
+            slug: "unshared-dwelling-flat-maisonette-or-apartment-total",
+          },
+          {
+            code: "QS402EW0008",
+            name: "Unshared dwelling: Flat, maisonette or apartment: Purpose-built block of flats or tenement",
+            slug: "unshared-dwelling-flat-maisonette-or-apartment-purpose-built-block-of-flats-or-tenement",
+          },
+          {
+            code: "QS402EW0009",
+            name: "Unshared dwelling: Flat, maisonette or apartment: Part of a converted or shared house (including bed-sits)",
+            slug: "unshared-dwelling-flat-maisonette-or-apartment-part-of-a-converted-or-shared-house-including-bed-sits",
+          },
+          {
+            code: "QS402EW0010",
+            name: "Unshared dwelling: Flat, maisonette or apartment: In commercial building",
+            slug: "unshared-dwelling-flat-maisonette-or-apartment-in-commercial-building",
+          },
+          {
+            code: "QS402EW0011",
+            name: "Unshared dwelling: Caravan or other mobile or temporary structure",
+            slug: "unshared-dwelling-caravan-or-other-mobile-or-temporary-structure",
+          },
+          {
+            code: "QS402EW0012",
+            name: "Shared dwelling",
+            slug: "shared-dwelling",
+          },
+        ],
+        code: "QS402EW",
+        name: "Owned and renting",
+        slug: "owned-and-renting",
+        desc: "People that live in a home they rent or own.",
+        total: {
+          code: "QS402EW0001",
+          name: "All categories: Accommodation type",
+          slug: "all-categories-accommodation-type",
+        },
+        units: "Households",
+      },
+      {
+        categories: [
+          {
+            code: "QS416EW0002",
+            name: "No cars or vans in household",
+            slug: "no-cars-or-vans-in-household",
+          },
+          {
+            code: "QS416EW0003",
+            name: "1 car or van in household",
+            slug: "1-car-or-van-in-household",
+          },
+          {
+            code: "QS416EW0004",
+            name: "2 cars or vans in household",
+            slug: "2-cars-or-vans-in-household",
+          },
+          {
+            code: "QS416EW0005",
+            name: "3 cars or vans in household",
+            slug: "3-cars-or-vans-in-household",
+          },
+          {
+            code: "QS416EW0006",
+            name: "4 or more cars or vans in household",
+            slug: "4-or-more-cars-or-vans-in-household",
+          },
+          {
+            code: "QS416EW0007",
+            name: "All categories: Car or van availability",
+            slug: "all-categories-car-or-van-availability",
+          },
+        ],
+        code: "QS416EW",
+        name: "Car or van availability",
+        slug: "car-or-van-availability",
+        desc: "People that have access to cars or vans.",
+        total: {
+          code: "QS416EW0001",
+          name: "All categories: Car or van availability",
+          slug: "all-categories-car-or-van-availability",
+        },
+        units: "Households",
+      },
+      {
+        categories: [
+          {
+            code: "QS415EW0002",
+            name: "No central heating",
+            slug: "no-central-heating",
+          },
+          {
+            code: "QS415EW0003",
+            name: "Gas central heating",
+            slug: "gas-central-heating",
+          },
+          {
+            code: "QS415EW0004",
+            name: "Electric (including storage heaters) central heating",
+            slug: "electric-including-storage-heaters-central-heating",
+          },
+          {
+            code: "QS415EW0005",
+            name: "Oil central heating",
+            slug: "oil-central-heating",
+          },
+          {
+            code: "QS415EW0006",
+            name: "Solid fuel (for example wood, coal) central heating",
+            slug: "solid-fuel-for-example-wood-coal-central-heating",
+          },
+          {
+            code: "QS415EW0007",
+            name: "Other central heating",
+            slug: "other-central-heating",
+          },
+          {
+            code: "QS415EW0008",
+            name: "Two or more types of central heating",
+            slug: "two-or-more-types-of-central-heating",
+          },
+        ],
+        code: "QS415EW",
+        name: "Heating",
+        slug: "heating",
+        desc: "Types of central heating",
+        total: {
+          code: "QS415EW0001",
+          name: "All categories: Type of central heating in household",
+          slug: "all-categories-type-of-central-heating-in-household",
+        },
+        units: "Households",
+      },
+      {
+        categories: [
+          {
+            code: "QS106EW0002",
+            name: "No second address",
+            slug: "no-second-address",
+          },
+          {
+            code: "QS106EW0003",
+            name: "Second address within the UK",
+            slug: "second-address-within-the-uk",
+          },
+          {
+            code: "QS106EW0004",
+            name: "Second address outside the UK",
+            slug: "second-address-outside-the-uk",
+          },
+        ],
+        code: "QS106EW",
+        name: "Second address",
+        slug: "second-address",
+        desc: "",
+        total: {
+          code: "QS106EW0001",
+          name: "All categories: Second address",
+          slug: "all-categories-second-address",
+        },
+        units: "People (usual residents)",
+      },
+    ],
   },
   {
-      "code": "Identity",
-      "name": "Identity",
-      "slug": "identity",
-      "desc": "How residents identify themselves and their beliefs.",
-      "tables": [
+    code: "Identity",
+    name: "Identity",
+    slug: "identity",
+    desc: "How residents identify themselves and their beliefs.",
+    tables: [
+      {
+        categories: [
           {
-              "categories": [
-                  {
-                      "code": "QS201EW0002",
-                      "name": "White: English/Welsh/Scottish/Northern Irish/British",
-                      "slug": "white-english-welsh-scottish-northern-irish-british"
-                  },
-                  {
-                      "code": "QS201EW0003",
-                      "name": "White: Irish",
-                      "slug": "white-irish"
-                  },
-                  {
-                      "code": "QS201EW0004",
-                      "name": "White: Gypsy or Irish Traveller",
-                      "slug": "white-gypsy-or-irish-traveller"
-                  },
-                  {
-                      "code": "QS201EW0005",
-                      "name": "White: Other White",
-                      "slug": "white-other-white"
-                  },
-                  {
-                      "code": "QS201EW0006",
-                      "name": "Mixed/multiple ethnic group: White and Black Caribbean",
-                      "slug": "mixed-multiple-ethnic-group-white-and-black-caribbean"
-                  },
-                  {
-                      "code": "QS201EW0007",
-                      "name": "Mixed/multiple ethnic group: White and Black African",
-                      "slug": "mixed-multiple-ethnic-group-white-and-black-african"
-                  },
-                  {
-                      "code": "QS201EW0008",
-                      "name": "Mixed/multiple ethnic group: White and Asian",
-                      "slug": "mixed-multiple-ethnic-group-white-and-asian"
-                  },
-                  {
-                      "code": "QS201EW0009",
-                      "name": "Mixed/multiple ethnic group: Other Mixed",
-                      "slug": "mixed-multiple-ethnic-group-other-mixed"
-                  },
-                  {
-                      "code": "QS201EW0010",
-                      "name": "Asian/Asian British: Indian",
-                      "slug": "asian-asian-british-indian"
-                  },
-                  {
-                      "code": "QS201EW0011",
-                      "name": "Asian/Asian British: Pakistani",
-                      "slug": "asian-asian-british-pakistani"
-                  },
-                  {
-                      "code": "QS201EW0012",
-                      "name": "Asian/Asian British: Bangladeshi",
-                      "slug": "asian-asian-british-bangladeshi"
-                  },
-                  {
-                      "code": "QS201EW0013",
-                      "name": "Asian/Asian British: Chinese",
-                      "slug": "asian-asian-british-chinese"
-                  },
-                  {
-                      "code": "QS201EW0014",
-                      "name": "Asian/Asian British: Other Asian",
-                      "slug": "asian-asian-british-other-asian"
-                  },
-                  {
-                      "code": "QS201EW0015",
-                      "name": "Black/African/Caribbean/Black British: African",
-                      "slug": "black-african-caribbean-black-british-african"
-                  },
-                  {
-                      "code": "QS201EW0016",
-                      "name": "Black/African/Caribbean/Black British: Caribbean",
-                      "slug": "black-african-caribbean-black-british-caribbean"
-                  },
-                  {
-                      "code": "QS201EW0017",
-                      "name": "Black/African/Caribbean/Black British: Other Black",
-                      "slug": "black-african-caribbean-black-british-other-black"
-                  },
-                  {
-                      "code": "QS201EW0018",
-                      "name": "Other ethnic group: Arab",
-                      "slug": "other-ethnic-group-arab"
-                  },
-                  {
-                      "code": "QS201EW0019",
-                      "name": "Other ethnic group: Any other ethnic group",
-                      "slug": "other-ethnic-group-any-other-ethnic-group"
-                  }
-              ],
-              "code": "QS201EW",
-              "name": "Ethnicity",
-              "slug": "ethnicity",
-              "desc": "How people identify the ethnic group they belong to.",
-              "total": {
-                  "code": "QS201EW0001",
-                  "name": "All categories: Ethnic group",
-                  "slug": "all-categories-ethnic-group"
-              },
-              "units": "People (usual residents)"
+            code: "QS201EW0002",
+            name: "White: English/Welsh/Scottish/Northern Irish/British",
+            slug: "white-english-welsh-scottish-northern-irish-british",
           },
           {
-              "categories": [
-                  {
-                      "code": "QS202EW0002",
-                      "name": "One person household",
-                      "slug": "one-person-household"
-                  },
-                  {
-                      "code": "QS202EW0003",
-                      "name": "All household members have the same ethnic group",
-                      "slug": "all-household-members-have-the-same-ethnic-group"
-                  },
-                  {
-                      "code": "QS202EW0004",
-                      "name": "Different ethnic groups between the generations only",
-                      "slug": "different-ethnic-groups-between-the-generations-only"
-                  },
-                  {
-                      "code": "QS202EW0005",
-                      "name": "Different ethnic groups within partnerships (whether or not different ethnic groups between generations)",
-                      "slug": "different-ethnic-groups-within-partnerships-whether-or-not-different-ethnic-groups-between-generations"
-                  },
-                  {
-                      "code": "QS202EW0006",
-                      "name": "Any other combination of multiple ethnic groups",
-                      "slug": "any-other-combination-of-multiple-ethnic-groups"
-                  }
-              ],
-              "code": "QS202EW",
-              "name": "Households with more than one ethnic group",
-              "slug": "households-with-more-than-one-ethnic-group",
-              "desc": "",
-              "total": {
-                  "code": "QS202EW0001",
-                  "name": "All categories: Multiple ethnic groups",
-                  "slug": "all-categories-multiple-ethnic-groups"
-              },
-              "units": "Households"
+            code: "QS201EW0003",
+            name: "White: Irish",
+            slug: "white-irish",
           },
           {
-              "categories": [
-                  {
-                      "code": "KS202EW0002",
-                      "name": "English only identity",
-                      "slug": "english-only-identity"
-                  },
-                  {
-                      "code": "KS202EW0003",
-                      "name": "English and British only identity",
-                      "slug": "english-and-british-only-identity"
-                  },
-                  {
-                      "code": "KS202EW0004",
-                      "name": "Other English combined background identity",
-                      "slug": "other-english-combined-background-identity"
-                  },
-                  {
-                      "code": "KS202EW0005",
-                      "name": "No English identity",
-                      "slug": "no-english-identity"
-                  },
-                  {
-                      "code": "KS202EW0006",
-                      "name": "All categories: National identity Welsh",
-                      "slug": "all-categories-national-identity-welsh"
-                  },
-                  {
-                      "code": "KS202EW0007",
-                      "name": "Welsh only identity",
-                      "slug": "welsh-only-identity"
-                  },
-                  {
-                      "code": "KS202EW0008",
-                      "name": "Welsh and British only identity",
-                      "slug": "welsh-and-british-only-identity"
-                  },
-                  {
-                      "code": "KS202EW0009",
-                      "name": "Other Welsh combined background identity",
-                      "slug": "other-welsh-combined-background-identity"
-                  },
-                  {
-                      "code": "KS202EW0010",
-                      "name": "No Welsh identity",
-                      "slug": "no-welsh-identity"
-                  },
-                  {
-                      "code": "KS202EW0011",
-                      "name": "All categories: National identity Scottish",
-                      "slug": "all-categories-national-identity-scottish"
-                  },
-                  {
-                      "code": "KS202EW0012",
-                      "name": "Scottish only identity",
-                      "slug": "scottish-only-identity"
-                  },
-                  {
-                      "code": "KS202EW0013",
-                      "name": "Scottish and British only identity",
-                      "slug": "scottish-and-british-only-identity"
-                  },
-                  {
-                      "code": "KS202EW0014",
-                      "name": "Other Scottish combined background identity",
-                      "slug": "other-scottish-combined-background-identity"
-                  },
-                  {
-                      "code": "KS202EW0015",
-                      "name": "No Scottish identity",
-                      "slug": "no-scottish-identity"
-                  },
-                  {
-                      "code": "KS202EW0016",
-                      "name": "All categories: National identity Northern Irish",
-                      "slug": "all-categories-national-identity-northern-irish"
-                  },
-                  {
-                      "code": "KS202EW0017",
-                      "name": "Northern Irish only identity",
-                      "slug": "northern-irish-only-identity"
-                  },
-                  {
-                      "code": "KS202EW0018",
-                      "name": "Northern Irish and British only identity",
-                      "slug": "northern-irish-and-british-only-identity"
-                  },
-                  {
-                      "code": "KS202EW0019",
-                      "name": "Other Northern Irish combined background identity",
-                      "slug": "other-northern-irish-combined-background-identity"
-                  },
-                  {
-                      "code": "KS202EW0020",
-                      "name": "No Northern Irish identity",
-                      "slug": "no-northern-irish-identity"
-                  },
-                  {
-                      "code": "KS202EW0021",
-                      "name": "All categories: National identity British",
-                      "slug": "all-categories-national-identity-british"
-                  },
-                  {
-                      "code": "KS202EW0022",
-                      "name": "British only identity",
-                      "slug": "british-only-identity"
-                  },
-                  {
-                      "code": "KS202EW0023",
-                      "name": "British and any other identity",
-                      "slug": "british-and-any-other-identity"
-                  },
-                  {
-                      "code": "KS202EW0024",
-                      "name": "No British identity",
-                      "slug": "no-british-identity"
-                  },
-                  {
-                      "code": "KS202EW0025",
-                      "name": "All categories: National identity Cornish",
-                      "slug": "all-categories-national-identity-cornish"
-                  },
-                  {
-                      "code": "KS202EW0026",
-                      "name": "Cornish only identity",
-                      "slug": "cornish-only-identity"
-                  },
-                  {
-                      "code": "KS202EW0027",
-                      "name": "Cornish and British only identity",
-                      "slug": "cornish-and-british-only-identity"
-                  },
-                  {
-                      "code": "KS202EW0028",
-                      "name": "Cornish and at least one of English/Welsh/Scottish/Northern Irish identities (with or without British)",
-                      "slug": "cornish-and-at-least-one-of-english-welsh-scottish-northern-irish-identities-with-or-without-british"
-                  },
-                  {
-                      "code": "KS202EW0029",
-                      "name": "No Cornish identity",
-                      "slug": "no-cornish-identity"
-                  },
-                  {
-                      "code": "KS202EW0030",
-                      "name": "All categories: National identity Irish",
-                      "slug": "all-categories-national-identity-irish"
-                  },
-                  {
-                      "code": "KS202EW0031",
-                      "name": "Irish only identity",
-                      "slug": "irish-only-identity"
-                  },
-                  {
-                      "code": "KS202EW0032",
-                      "name": "Irish and British only identity",
-                      "slug": "irish-and-british-only-identity"
-                  },
-                  {
-                      "code": "KS202EW0033",
-                      "name": "Irish and Northern Irish only identity",
-                      "slug": "irish-and-northern-irish-only-identity"
-                  },
-                  {
-                      "code": "KS202EW0034",
-                      "name": "Irish, Northern Irish and British only identity",
-                      "slug": "irish-northern-irish-and-british-only-identity"
-                  },
-                  {
-                      "code": "KS202EW0035",
-                      "name": "Irish and at least one of English/Welsh/Scottish identities (with or without British)",
-                      "slug": "irish-and-at-least-one-of-english-welsh-scottish-identities-with-or-without-british"
-                  },
-                  {
-                      "code": "KS202EW0036",
-                      "name": "Irish, Northern Irish and at least one of English/Welsh/Scottish identities (with or without British)",
-                      "slug": "irish-northern-irish-and-at-least-one-of-english-welsh-scottish-identities-with-or-without-british"
-                  },
-                  {
-                      "code": "KS202EW0037",
-                      "name": "No Irish identity",
-                      "slug": "no-irish-identity"
-                  },
-                  {
-                      "code": "KS202EW0038",
-                      "name": "All categories: National identity Other",
-                      "slug": "all-categories-national-identity-other"
-                  },
-                  {
-                      "code": "KS202EW0039",
-                      "name": "Other identities only",
-                      "slug": "other-identities-only"
-                  },
-                  {
-                      "code": "KS202EW0040",
-                      "name": "Other identities and at least one of English/Welsh/Scottish/Northern Irish/British only",
-                      "slug": "other-identities-and-at-least-one-of-english-welsh-scottish-northern-irish-british-only"
-                  },
-                  {
-                      "code": "KS202EW0041",
-                      "name": "At least one of English/Welsh/Scottish/Northern Irish/British identities only",
-                      "slug": "at-least-one-of-english-welsh-scottish-northern-irish-british-identities-only"
-                  },
-                  {
-                      "code": "KS202EW0042",
-                      "name": "English only identity",
-                      "slug": "english-only-identity"
-                  },
-                  {
-                      "code": "KS202EW0043",
-                      "name": "English and British only identity",
-                      "slug": "english-and-british-only-identity"
-                  },
-                  {
-                      "code": "KS202EW0044",
-                      "name": "Other English combined background identity",
-                      "slug": "other-english-combined-background-identity"
-                  },
-                  {
-                      "code": "KS202EW0045",
-                      "name": "No English identity",
-                      "slug": "no-english-identity"
-                  },
-                  {
-                      "code": "KS202EW0046",
-                      "name": "Welsh only identity",
-                      "slug": "welsh-only-identity"
-                  },
-                  {
-                      "code": "KS202EW0047",
-                      "name": "Welsh and British only identity",
-                      "slug": "welsh-and-british-only-identity"
-                  },
-                  {
-                      "code": "KS202EW0048",
-                      "name": "Other Welsh combined background identity",
-                      "slug": "other-welsh-combined-background-identity"
-                  },
-                  {
-                      "code": "KS202EW0049",
-                      "name": "No Welsh identity",
-                      "slug": "no-welsh-identity"
-                  },
-                  {
-                      "code": "KS202EW0050",
-                      "name": "Scottish only identity",
-                      "slug": "scottish-only-identity"
-                  },
-                  {
-                      "code": "KS202EW0051",
-                      "name": "Scottish and British only identity",
-                      "slug": "scottish-and-british-only-identity"
-                  },
-                  {
-                      "code": "KS202EW0052",
-                      "name": "Other Scottish combined background identity",
-                      "slug": "other-scottish-combined-background-identity"
-                  },
-                  {
-                      "code": "KS202EW0053",
-                      "name": "No Scottish identity",
-                      "slug": "no-scottish-identity"
-                  },
-                  {
-                      "code": "KS202EW0054",
-                      "name": "Northern Irish only identity",
-                      "slug": "northern-irish-only-identity"
-                  },
-                  {
-                      "code": "KS202EW0055",
-                      "name": "Northern Irish and British only identity",
-                      "slug": "northern-irish-and-british-only-identity"
-                  },
-                  {
-                      "code": "KS202EW0056",
-                      "name": "Other Northern Irish combined background identity",
-                      "slug": "other-northern-irish-combined-background-identity"
-                  },
-                  {
-                      "code": "KS202EW0057",
-                      "name": "No Northern Irish identity",
-                      "slug": "no-northern-irish-identity"
-                  },
-                  {
-                      "code": "KS202EW0058",
-                      "name": "British only identity",
-                      "slug": "british-only-identity"
-                  },
-                  {
-                      "code": "KS202EW0059",
-                      "name": "British and any other identity",
-                      "slug": "british-and-any-other-identity"
-                  },
-                  {
-                      "code": "KS202EW0060",
-                      "name": "No British identity",
-                      "slug": "no-british-identity"
-                  },
-                  {
-                      "code": "KS202EW0061",
-                      "name": "Cornish only identity",
-                      "slug": "cornish-only-identity"
-                  },
-                  {
-                      "code": "KS202EW0062",
-                      "name": "Cornish and British only identity",
-                      "slug": "cornish-and-british-only-identity"
-                  },
-                  {
-                      "code": "KS202EW0063",
-                      "name": "Cornish and at least one of English/Welsh/Scottish/Northern Irish identities (with or without British)",
-                      "slug": "cornish-and-at-least-one-of-english-welsh-scottish-northern-irish-identities-with-or-without-british"
-                  },
-                  {
-                      "code": "KS202EW0064",
-                      "name": "No Cornish identity",
-                      "slug": "no-cornish-identity"
-                  },
-                  {
-                      "code": "KS202EW0065",
-                      "name": "Irish only identity",
-                      "slug": "irish-only-identity"
-                  },
-                  {
-                      "code": "KS202EW0066",
-                      "name": "Irish and British only identity",
-                      "slug": "irish-and-british-only-identity"
-                  },
-                  {
-                      "code": "KS202EW0067",
-                      "name": "Irish and Northern Irish only identity",
-                      "slug": "irish-and-northern-irish-only-identity"
-                  },
-                  {
-                      "code": "KS202EW0068",
-                      "name": "Irish, Northern Irish and British only identity",
-                      "slug": "irish-northern-irish-and-british-only-identity"
-                  },
-                  {
-                      "code": "KS202EW0069",
-                      "name": "Irish and at least one of English/Welsh/Scottish identities (with or without British)",
-                      "slug": "irish-and-at-least-one-of-english-welsh-scottish-identities-with-or-without-british"
-                  },
-                  {
-                      "code": "KS202EW0070",
-                      "name": "Irish, Northern Irish and at least one of English/Welsh/Scottish identities (with or without British)",
-                      "slug": "irish-northern-irish-and-at-least-one-of-english-welsh-scottish-identities-with-or-without-british"
-                  },
-                  {
-                      "code": "KS202EW0071",
-                      "name": "No Irish identity",
-                      "slug": "no-irish-identity"
-                  },
-                  {
-                      "code": "KS202EW0072",
-                      "name": "Other identities only",
-                      "slug": "other-identities-only"
-                  },
-                  {
-                      "code": "KS202EW0073",
-                      "name": "Other identities and at least one of English/Welsh/Scottish/Northern Irish/British only",
-                      "slug": "other-identities-and-at-least-one-of-english-welsh-scottish-northern-irish-british-only"
-                  },
-                  {
-                      "code": "KS202EW0074",
-                      "name": "At least one of English/Welsh/Scottish/Northern Irish/British identities only",
-                      "slug": "at-least-one-of-english-welsh-scottish-northern-irish-british-identities-only"
-                  }
-              ],
-              "code": "KS202EW",
-              "name": "National identity",
-              "slug": "national-identity",
-              "desc": "The countries people think of as home.",
-              "total": {
-                  "code": "KS202EW0001",
-                  "name": "All categories: National identity English",
-                  "slug": "all-categories-national-identity-english"
-              },
-              "units": "People (usual residents)"
+            code: "QS201EW0004",
+            name: "White: Gypsy or Irish Traveller",
+            slug: "white-gypsy-or-irish-traveller",
           },
           {
-              "categories": [
-                  {
-                      "code": "QS208EW0002",
-                      "name": "Christian",
-                      "slug": "christian"
-                  },
-                  {
-                      "code": "QS208EW0003",
-                      "name": "Buddhist",
-                      "slug": "buddhist"
-                  },
-                  {
-                      "code": "QS208EW0004",
-                      "name": "Hindu",
-                      "slug": "hindu"
-                  },
-                  {
-                      "code": "QS208EW0005",
-                      "name": "Jewish",
-                      "slug": "jewish"
-                  },
-                  {
-                      "code": "QS208EW0006",
-                      "name": "Muslim",
-                      "slug": "muslim"
-                  },
-                  {
-                      "code": "QS208EW0007",
-                      "name": "Sikh",
-                      "slug": "sikh"
-                  },
-                  {
-                      "code": "QS208EW0008",
-                      "name": "Other religion",
-                      "slug": "other-religion"
-                  },
-                  {
-                      "code": "QS208EW0009",
-                      "name": "No religion",
-                      "slug": "no-religion"
-                  },
-                  {
-                      "code": "QS208EW0010",
-                      "name": "Religion not stated",
-                      "slug": "religion-not-stated"
-                  }
-              ],
-              "code": "QS208EW",
-              "name": "Religion and beliefs",
-              "slug": "religion-and-beliefs",
-              "desc": "People's religion and beliefs. ",
-              "total": {
-                  "code": "QS208EW0001",
-                  "name": "All categories: Religion",
-                  "slug": "all-categories-religion"
-              },
-              "units": "People (usual residents)"
+            code: "QS201EW0005",
+            name: "White: Other White",
+            slug: "white-other-white",
           },
           {
-              "categories": [
-                  {
-                      "code": "QS203EW0002",
-                      "name": "Europe: Total",
-                      "slug": "europe-total"
-                  },
-                  {
-                      "code": "QS203EW0003",
-                      "name": "Europe: United Kingdom: Total",
-                      "slug": "europe-united-kingdom-total"
-                  },
-                  {
-                      "code": "QS203EW0004",
-                      "name": "Europe: United Kingdom: England",
-                      "slug": "europe-united-kingdom-england"
-                  },
-                  {
-                      "code": "QS203EW0005",
-                      "name": "Europe: United Kingdom: Northern Ireland",
-                      "slug": "europe-united-kingdom-northern-ireland"
-                  },
-                  {
-                      "code": "QS203EW0006",
-                      "name": "Europe: United Kingdom: Scotland",
-                      "slug": "europe-united-kingdom-scotland"
-                  },
-                  {
-                      "code": "QS203EW0007",
-                      "name": "Europe: United Kingdom: Wales",
-                      "slug": "europe-united-kingdom-wales"
-                  },
-                  {
-                      "code": "QS203EW0008",
-                      "name": "Europe: Great Britain not otherwise specified",
-                      "slug": "europe-great-britain-not-otherwise-specified"
-                  },
-                  {
-                      "code": "QS203EW0009",
-                      "name": "Europe: United Kingdom not otherwise specified",
-                      "slug": "europe-united-kingdom-not-otherwise-specified"
-                  },
-                  {
-                      "code": "QS203EW0010",
-                      "name": "Europe: Guernsey",
-                      "slug": "europe-guernsey"
-                  },
-                  {
-                      "code": "QS203EW0011",
-                      "name": "Europe: Jersey",
-                      "slug": "europe-jersey"
-                  },
-                  {
-                      "code": "QS203EW0012",
-                      "name": "Europe: Channel Islands not otherwise specified",
-                      "slug": "europe-channel-islands-not-otherwise-specified"
-                  },
-                  {
-                      "code": "QS203EW0013",
-                      "name": "Europe: Isle of Man",
-                      "slug": "europe-isle-of-man"
-                  },
-                  {
-                      "code": "QS203EW0014",
-                      "name": "Europe: Ireland",
-                      "slug": "europe-ireland"
-                  },
-                  {
-                      "code": "QS203EW0015",
-                      "name": "Europe: Other Europe: Total",
-                      "slug": "europe-other-europe-total"
-                  },
-                  {
-                      "code": "QS203EW0016",
-                      "name": "Europe: Other Europe: EU Countries: Total",
-                      "slug": "europe-other-europe-eu-countries-total"
-                  },
-                  {
-                      "code": "QS203EW0017",
-                      "name": "Europe: Other Europe: EU countries: Member countries in March 2001: Total",
-                      "slug": "europe-other-europe-eu-countries-member-countries-in-march-2001-total"
-                  },
-                  {
-                      "code": "QS203EW0018",
-                      "name": "Europe: Other Europe: EU countries: Member countries in March 2001: France",
-                      "slug": "europe-other-europe-eu-countries-member-countries-in-march-2001-france"
-                  },
-                  {
-                      "code": "QS203EW0019",
-                      "name": "Europe: Other Europe: EU countries: Member countries in March 2001: Germany",
-                      "slug": "europe-other-europe-eu-countries-member-countries-in-march-2001-germany"
-                  },
-                  {
-                      "code": "QS203EW0020",
-                      "name": "Europe: Other Europe: EU countries: Member countries in March 2001: Italy",
-                      "slug": "europe-other-europe-eu-countries-member-countries-in-march-2001-italy"
-                  },
-                  {
-                      "code": "QS203EW0021",
-                      "name": "Europe: Other Europe: EU countries: Member countries in March 2001: Portugal",
-                      "slug": "europe-other-europe-eu-countries-member-countries-in-march-2001-portugal"
-                  },
-                  {
-                      "code": "QS203EW0022",
-                      "name": "Europe: Other Europe: EU countries: Member countries in March 2001: Spain (including Canary Islands)",
-                      "slug": "europe-other-europe-eu-countries-member-countries-in-march-2001-spain-including-canary-islands"
-                  },
-                  {
-                      "code": "QS203EW0023",
-                      "name": "Europe: Other Europe: EU countries: Member countries in March 2001: Other member countries in March 2001",
-                      "slug": "europe-other-europe-eu-countries-member-countries-in-march-2001-other-member-countries-in-march-2001"
-                  },
-                  {
-                      "code": "QS203EW0024",
-                      "name": "Europe: Other Europe: EU countries: Accession countries April 2001 to March 2011: Total",
-                      "slug": "europe-other-europe-eu-countries-accession-countries-april-2001-to-march-2011-total"
-                  },
-                  {
-                      "code": "QS203EW0025",
-                      "name": "Europe: Other Europe: EU countries: Accession countries April 2001 to March 2011: Lithuania",
-                      "slug": "europe-other-europe-eu-countries-accession-countries-april-2001-to-march-2011-lithuania"
-                  },
-                  {
-                      "code": "QS203EW0026",
-                      "name": "Europe: Other Europe: EU countries: Accession countries April 2001 to March 2011: Poland",
-                      "slug": "europe-other-europe-eu-countries-accession-countries-april-2001-to-march-2011-poland"
-                  },
-                  {
-                      "code": "QS203EW0027",
-                      "name": "Europe: Other Europe: EU countries: Accession countries April 2001 to March 2011: Romania",
-                      "slug": "europe-other-europe-eu-countries-accession-countries-april-2001-to-march-2011-romania"
-                  },
-                  {
-                      "code": "QS203EW0028",
-                      "name": "Europe: Other Europe: EU countries: Accession countries April 2001 to March 2011: Other EU accession countries",
-                      "slug": "europe-other-europe-eu-countries-accession-countries-april-2001-to-march-2011-other-eu-accession-countries"
-                  },
-                  {
-                      "code": "QS203EW0029",
-                      "name": "Europe: Other Europe: Rest of Europe: Total",
-                      "slug": "europe-other-europe-rest-of-europe-total"
-                  },
-                  {
-                      "code": "QS203EW0030",
-                      "name": "Europe: Other Europe: Rest of Europe: Turkey",
-                      "slug": "europe-other-europe-rest-of-europe-turkey"
-                  },
-                  {
-                      "code": "QS203EW0031",
-                      "name": "Europe: Other Europe: Rest of Europe: Other Europe",
-                      "slug": "europe-other-europe-rest-of-europe-other-europe"
-                  },
-                  {
-                      "code": "QS203EW0032",
-                      "name": "Africa: Total",
-                      "slug": "africa-total"
-                  },
-                  {
-                      "code": "QS203EW0033",
-                      "name": "Africa: North Africa",
-                      "slug": "africa-north-africa"
-                  },
-                  {
-                      "code": "QS203EW0034",
-                      "name": "Africa: Central and Western Africa: Total",
-                      "slug": "africa-central-and-western-africa-total"
-                  },
-                  {
-                      "code": "QS203EW0035",
-                      "name": "Africa: Central and Western Africa: Ghana",
-                      "slug": "africa-central-and-western-africa-ghana"
-                  },
-                  {
-                      "code": "QS203EW0036",
-                      "name": "Africa: Central and Western Africa: Nigeria",
-                      "slug": "africa-central-and-western-africa-nigeria"
-                  },
-                  {
-                      "code": "QS203EW0037",
-                      "name": "Africa: Central and Western Africa: Other Central and Western Africa",
-                      "slug": "africa-central-and-western-africa-other-central-and-western-africa"
-                  },
-                  {
-                      "code": "QS203EW0038",
-                      "name": "Africa: South and Eastern Africa: Total",
-                      "slug": "africa-south-and-eastern-africa-total"
-                  },
-                  {
-                      "code": "QS203EW0039",
-                      "name": "Africa: South and Eastern Africa: Kenya",
-                      "slug": "africa-south-and-eastern-africa-kenya"
-                  },
-                  {
-                      "code": "QS203EW0040",
-                      "name": "Africa: South and Eastern Africa: Somalia",
-                      "slug": "africa-south-and-eastern-africa-somalia"
-                  },
-                  {
-                      "code": "QS203EW0041",
-                      "name": "Africa: South and Eastern Africa: South Africa",
-                      "slug": "africa-south-and-eastern-africa-south-africa"
-                  },
-                  {
-                      "code": "QS203EW0042",
-                      "name": "Africa: South and Eastern Africa: Zimbabwe",
-                      "slug": "africa-south-and-eastern-africa-zimbabwe"
-                  },
-                  {
-                      "code": "QS203EW0043",
-                      "name": "Africa: South and Eastern Africa: Other South and Eastern Africa",
-                      "slug": "africa-south-and-eastern-africa-other-south-and-eastern-africa"
-                  },
-                  {
-                      "code": "QS203EW0044",
-                      "name": "Africa: Africa not otherwise specified",
-                      "slug": "africa-africa-not-otherwise-specified"
-                  },
-                  {
-                      "code": "QS203EW0045",
-                      "name": "Middle East and Asia: Total",
-                      "slug": "middle-east-and-asia-total"
-                  },
-                  {
-                      "code": "QS203EW0046",
-                      "name": "Middle East and Asia: Middle East: Total",
-                      "slug": "middle-east-and-asia-middle-east-total"
-                  },
-                  {
-                      "code": "QS203EW0047",
-                      "name": "Middle East and Asia: Middle East: Iran",
-                      "slug": "middle-east-and-asia-middle-east-iran"
-                  },
-                  {
-                      "code": "QS203EW0048",
-                      "name": "Middle East and Asia: Middle East: Other Middle East",
-                      "slug": "middle-east-and-asia-middle-east-other-middle-east"
-                  },
-                  {
-                      "code": "QS203EW0049",
-                      "name": "Middle East and Asia: Eastern Asia: Total",
-                      "slug": "middle-east-and-asia-eastern-asia-total"
-                  },
-                  {
-                      "code": "QS203EW0050",
-                      "name": "Middle East and Asia: Eastern Asia: China",
-                      "slug": "middle-east-and-asia-eastern-asia-china"
-                  },
-                  {
-                      "code": "QS203EW0051",
-                      "name": "Middle East and Asia: Eastern Asia: Hong Kong (Special Administrative Region of China)",
-                      "slug": "middle-east-and-asia-eastern-asia-hong-kong-special-administrative-region-of-china"
-                  },
-                  {
-                      "code": "QS203EW0052",
-                      "name": "Middle East and Asia: Eastern Asia: Other Eastern Asia",
-                      "slug": "middle-east-and-asia-eastern-asia-other-eastern-asia"
-                  },
-                  {
-                      "code": "QS203EW0053",
-                      "name": "Middle East and Asia: Southern Asia: Total",
-                      "slug": "middle-east-and-asia-southern-asia-total"
-                  },
-                  {
-                      "code": "QS203EW0054",
-                      "name": "Middle East and Asia: Southern Asia: Bangladesh",
-                      "slug": "middle-east-and-asia-southern-asia-bangladesh"
-                  },
-                  {
-                      "code": "QS203EW0055",
-                      "name": "Middle East and Asia: Southern Asia: India",
-                      "slug": "middle-east-and-asia-southern-asia-india"
-                  },
-                  {
-                      "code": "QS203EW0056",
-                      "name": "Middle East and Asia: Southern Asia: Pakistan",
-                      "slug": "middle-east-and-asia-southern-asia-pakistan"
-                  },
-                  {
-                      "code": "QS203EW0057",
-                      "name": "Middle East and Asia: Southern Asia: Sri Lanka",
-                      "slug": "middle-east-and-asia-southern-asia-sri-lanka"
-                  },
-                  {
-                      "code": "QS203EW0058",
-                      "name": "Middle East and Asia: Southern Asia: Other Southern Asia",
-                      "slug": "middle-east-and-asia-southern-asia-other-southern-asia"
-                  },
-                  {
-                      "code": "QS203EW0059",
-                      "name": "Middle East and Asia: South-East Asia: Total",
-                      "slug": "middle-east-and-asia-south-east-asia-total"
-                  },
-                  {
-                      "code": "QS203EW0060",
-                      "name": "Middle East and Asia: South-East Asia: Philippines",
-                      "slug": "middle-east-and-asia-south-east-asia-philippines"
-                  },
-                  {
-                      "code": "QS203EW0061",
-                      "name": "Middle East and Asia: South-East Asia: Other South-East Asia",
-                      "slug": "middle-east-and-asia-south-east-asia-other-south-east-asia"
-                  },
-                  {
-                      "code": "QS203EW0062",
-                      "name": "Middle East and Asia: Central Asia",
-                      "slug": "middle-east-and-asia-central-asia"
-                  },
-                  {
-                      "code": "QS203EW0063",
-                      "name": "The Americas and the Caribbean: Total",
-                      "slug": "the-americas-and-the-caribbean-total"
-                  },
-                  {
-                      "code": "QS203EW0064",
-                      "name": "The Americas and the Caribbean: North America: Total",
-                      "slug": "the-americas-and-the-caribbean-north-america-total"
-                  },
-                  {
-                      "code": "QS203EW0065",
-                      "name": "The Americas and the Caribbean: North America: United States",
-                      "slug": "the-americas-and-the-caribbean-north-america-united-states"
-                  },
-                  {
-                      "code": "QS203EW0066",
-                      "name": "The Americas and the Caribbean: North America: Other North America",
-                      "slug": "the-americas-and-the-caribbean-north-america-other-north-america"
-                  },
-                  {
-                      "code": "QS203EW0067",
-                      "name": "The Americas and the Caribbean: Central America",
-                      "slug": "the-americas-and-the-caribbean-central-america"
-                  },
-                  {
-                      "code": "QS203EW0068",
-                      "name": "The Americas and the Caribbean: South America",
-                      "slug": "the-americas-and-the-caribbean-south-america"
-                  },
-                  {
-                      "code": "QS203EW0069",
-                      "name": "The Americas and the Caribbean: The Caribbean: Total",
-                      "slug": "the-americas-and-the-caribbean-the-caribbean-total"
-                  },
-                  {
-                      "code": "QS203EW0070",
-                      "name": "The Americas and the Caribbean: The Caribbean: Jamaica",
-                      "slug": "the-americas-and-the-caribbean-the-caribbean-jamaica"
-                  },
-                  {
-                      "code": "QS203EW0071",
-                      "name": "The Americas and the Caribbean: The Caribbean: Other Caribbean",
-                      "slug": "the-americas-and-the-caribbean-the-caribbean-other-caribbean"
-                  },
-                  {
-                      "code": "QS203EW0072",
-                      "name": "Antarctica and Oceania: Total",
-                      "slug": "antarctica-and-oceania-total"
-                  },
-                  {
-                      "code": "QS203EW0073",
-                      "name": "Antarctica and Oceania: Antarctica",
-                      "slug": "antarctica-and-oceania-antarctica"
-                  },
-                  {
-                      "code": "QS203EW0074",
-                      "name": "Antarctica and Oceania: Australasia: Total",
-                      "slug": "antarctica-and-oceania-australasia-total"
-                  },
-                  {
-                      "code": "QS203EW0075",
-                      "name": "Antarctica and Oceania: Australasia: Australia",
-                      "slug": "antarctica-and-oceania-australasia-australia"
-                  },
-                  {
-                      "code": "QS203EW0076",
-                      "name": "Antarctica and Oceania: Australasia: Other Australasia",
-                      "slug": "antarctica-and-oceania-australasia-other-australasia"
-                  },
-                  {
-                      "code": "QS203EW0077",
-                      "name": "Antarctica and Oceania: Other Oceania",
-                      "slug": "antarctica-and-oceania-other-oceania"
-                  },
-                  {
-                      "code": "QS203EW0078",
-                      "name": "Other",
-                      "slug": "other"
-                  }
-              ],
-              "code": "QS203EW",
-              "name": "Place of birth",
-              "slug": "place-of-birth",
-              "desc": "People born in or outside the UK.",
-              "total": {
-                  "code": "QS203EW0001",
-                  "name": "All categories: Country of birth",
-                  "slug": "all-categories-country-of-birth"
-              },
-              "units": "People (usual residents)"
+            code: "QS201EW0006",
+            name: "Mixed/multiple ethnic group: White and Black Caribbean",
+            slug: "mixed-multiple-ethnic-group-white-and-black-caribbean",
           },
           {
-              "categories": [
-                  {
-                      "code": "QS803EW0002",
-                      "name": "Born in the UK",
-                      "slug": "born-in-the-uk"
-                  },
-                  {
-                      "code": "QS803EW0003",
-                      "name": "Resident in UK: Less than 2 years",
-                      "slug": "resident-in-uk-less-than-2-years"
-                  },
-                  {
-                      "code": "QS803EW0004",
-                      "name": "Resident in UK: 2 years or more but less than 5 years",
-                      "slug": "resident-in-uk-2-years-or-more-but-less-than-5-years"
-                  },
-                  {
-                      "code": "QS803EW0005",
-                      "name": "Resident in UK: 5 years or more but less than 10 years",
-                      "slug": "resident-in-uk-5-years-or-more-but-less-than-10-years"
-                  },
-                  {
-                      "code": "QS803EW0006",
-                      "name": "Resident in UK: 10 years or more",
-                      "slug": "resident-in-uk-10-years-or-more"
-                  }
-              ],
-              "code": "QS803EW",
-              "name": "Length of time people have lived in the uk",
-              "slug": "length-of-time-people-have-lived-in-the-uk",
-              "desc": "People born or have moved to the UK,",
-              "total": {
-                  "code": "QS803EW0001",
-                  "name": "All categories: Length of residence in the UK",
-                  "slug": "all-categories-length-of-residence-in-the-uk"
-              },
-              "units": "People (usual residents)"
-          }
-      ]
+            code: "QS201EW0007",
+            name: "Mixed/multiple ethnic group: White and Black African",
+            slug: "mixed-multiple-ethnic-group-white-and-black-african",
+          },
+          {
+            code: "QS201EW0008",
+            name: "Mixed/multiple ethnic group: White and Asian",
+            slug: "mixed-multiple-ethnic-group-white-and-asian",
+          },
+          {
+            code: "QS201EW0009",
+            name: "Mixed/multiple ethnic group: Other Mixed",
+            slug: "mixed-multiple-ethnic-group-other-mixed",
+          },
+          {
+            code: "QS201EW0010",
+            name: "Asian/Asian British: Indian",
+            slug: "asian-asian-british-indian",
+          },
+          {
+            code: "QS201EW0011",
+            name: "Asian/Asian British: Pakistani",
+            slug: "asian-asian-british-pakistani",
+          },
+          {
+            code: "QS201EW0012",
+            name: "Asian/Asian British: Bangladeshi",
+            slug: "asian-asian-british-bangladeshi",
+          },
+          {
+            code: "QS201EW0013",
+            name: "Asian/Asian British: Chinese",
+            slug: "asian-asian-british-chinese",
+          },
+          {
+            code: "QS201EW0014",
+            name: "Asian/Asian British: Other Asian",
+            slug: "asian-asian-british-other-asian",
+          },
+          {
+            code: "QS201EW0015",
+            name: "Black/African/Caribbean/Black British: African",
+            slug: "black-african-caribbean-black-british-african",
+          },
+          {
+            code: "QS201EW0016",
+            name: "Black/African/Caribbean/Black British: Caribbean",
+            slug: "black-african-caribbean-black-british-caribbean",
+          },
+          {
+            code: "QS201EW0017",
+            name: "Black/African/Caribbean/Black British: Other Black",
+            slug: "black-african-caribbean-black-british-other-black",
+          },
+          {
+            code: "QS201EW0018",
+            name: "Other ethnic group: Arab",
+            slug: "other-ethnic-group-arab",
+          },
+          {
+            code: "QS201EW0019",
+            name: "Other ethnic group: Any other ethnic group",
+            slug: "other-ethnic-group-any-other-ethnic-group",
+          },
+        ],
+        code: "QS201EW",
+        name: "Ethnicity",
+        slug: "ethnicity",
+        desc: "How people identify the ethnic group they belong to.",
+        total: {
+          code: "QS201EW0001",
+          name: "All categories: Ethnic group",
+          slug: "all-categories-ethnic-group",
+        },
+        units: "People (usual residents)",
+      },
+      {
+        categories: [
+          {
+            code: "QS202EW0002",
+            name: "One person household",
+            slug: "one-person-household",
+          },
+          {
+            code: "QS202EW0003",
+            name: "All household members have the same ethnic group",
+            slug: "all-household-members-have-the-same-ethnic-group",
+          },
+          {
+            code: "QS202EW0004",
+            name: "Different ethnic groups between the generations only",
+            slug: "different-ethnic-groups-between-the-generations-only",
+          },
+          {
+            code: "QS202EW0005",
+            name: "Different ethnic groups within partnerships (whether or not different ethnic groups between generations)",
+            slug: "different-ethnic-groups-within-partnerships-whether-or-not-different-ethnic-groups-between-generations",
+          },
+          {
+            code: "QS202EW0006",
+            name: "Any other combination of multiple ethnic groups",
+            slug: "any-other-combination-of-multiple-ethnic-groups",
+          },
+        ],
+        code: "QS202EW",
+        name: "Households with more than one ethnic group",
+        slug: "households-with-more-than-one-ethnic-group",
+        desc: "",
+        total: {
+          code: "QS202EW0001",
+          name: "All categories: Multiple ethnic groups",
+          slug: "all-categories-multiple-ethnic-groups",
+        },
+        units: "Households",
+      },
+      {
+        categories: [
+          {
+            code: "KS202EW0002",
+            name: "English only identity",
+            slug: "english-only-identity",
+          },
+          {
+            code: "KS202EW0003",
+            name: "English and British only identity",
+            slug: "english-and-british-only-identity",
+          },
+          {
+            code: "KS202EW0004",
+            name: "Other English combined background identity",
+            slug: "other-english-combined-background-identity",
+          },
+          {
+            code: "KS202EW0005",
+            name: "No English identity",
+            slug: "no-english-identity",
+          },
+          {
+            code: "KS202EW0006",
+            name: "All categories: National identity Welsh",
+            slug: "all-categories-national-identity-welsh",
+          },
+          {
+            code: "KS202EW0007",
+            name: "Welsh only identity",
+            slug: "welsh-only-identity",
+          },
+          {
+            code: "KS202EW0008",
+            name: "Welsh and British only identity",
+            slug: "welsh-and-british-only-identity",
+          },
+          {
+            code: "KS202EW0009",
+            name: "Other Welsh combined background identity",
+            slug: "other-welsh-combined-background-identity",
+          },
+          {
+            code: "KS202EW0010",
+            name: "No Welsh identity",
+            slug: "no-welsh-identity",
+          },
+          {
+            code: "KS202EW0011",
+            name: "All categories: National identity Scottish",
+            slug: "all-categories-national-identity-scottish",
+          },
+          {
+            code: "KS202EW0012",
+            name: "Scottish only identity",
+            slug: "scottish-only-identity",
+          },
+          {
+            code: "KS202EW0013",
+            name: "Scottish and British only identity",
+            slug: "scottish-and-british-only-identity",
+          },
+          {
+            code: "KS202EW0014",
+            name: "Other Scottish combined background identity",
+            slug: "other-scottish-combined-background-identity",
+          },
+          {
+            code: "KS202EW0015",
+            name: "No Scottish identity",
+            slug: "no-scottish-identity",
+          },
+          {
+            code: "KS202EW0016",
+            name: "All categories: National identity Northern Irish",
+            slug: "all-categories-national-identity-northern-irish",
+          },
+          {
+            code: "KS202EW0017",
+            name: "Northern Irish only identity",
+            slug: "northern-irish-only-identity",
+          },
+          {
+            code: "KS202EW0018",
+            name: "Northern Irish and British only identity",
+            slug: "northern-irish-and-british-only-identity",
+          },
+          {
+            code: "KS202EW0019",
+            name: "Other Northern Irish combined background identity",
+            slug: "other-northern-irish-combined-background-identity",
+          },
+          {
+            code: "KS202EW0020",
+            name: "No Northern Irish identity",
+            slug: "no-northern-irish-identity",
+          },
+          {
+            code: "KS202EW0021",
+            name: "All categories: National identity British",
+            slug: "all-categories-national-identity-british",
+          },
+          {
+            code: "KS202EW0022",
+            name: "British only identity",
+            slug: "british-only-identity",
+          },
+          {
+            code: "KS202EW0023",
+            name: "British and any other identity",
+            slug: "british-and-any-other-identity",
+          },
+          {
+            code: "KS202EW0024",
+            name: "No British identity",
+            slug: "no-british-identity",
+          },
+          {
+            code: "KS202EW0025",
+            name: "All categories: National identity Cornish",
+            slug: "all-categories-national-identity-cornish",
+          },
+          {
+            code: "KS202EW0026",
+            name: "Cornish only identity",
+            slug: "cornish-only-identity",
+          },
+          {
+            code: "KS202EW0027",
+            name: "Cornish and British only identity",
+            slug: "cornish-and-british-only-identity",
+          },
+          {
+            code: "KS202EW0028",
+            name: "Cornish and at least one of English/Welsh/Scottish/Northern Irish identities (with or without British)",
+            slug: "cornish-and-at-least-one-of-english-welsh-scottish-northern-irish-identities-with-or-without-british",
+          },
+          {
+            code: "KS202EW0029",
+            name: "No Cornish identity",
+            slug: "no-cornish-identity",
+          },
+          {
+            code: "KS202EW0030",
+            name: "All categories: National identity Irish",
+            slug: "all-categories-national-identity-irish",
+          },
+          {
+            code: "KS202EW0031",
+            name: "Irish only identity",
+            slug: "irish-only-identity",
+          },
+          {
+            code: "KS202EW0032",
+            name: "Irish and British only identity",
+            slug: "irish-and-british-only-identity",
+          },
+          {
+            code: "KS202EW0033",
+            name: "Irish and Northern Irish only identity",
+            slug: "irish-and-northern-irish-only-identity",
+          },
+          {
+            code: "KS202EW0034",
+            name: "Irish, Northern Irish and British only identity",
+            slug: "irish-northern-irish-and-british-only-identity",
+          },
+          {
+            code: "KS202EW0035",
+            name: "Irish and at least one of English/Welsh/Scottish identities (with or without British)",
+            slug: "irish-and-at-least-one-of-english-welsh-scottish-identities-with-or-without-british",
+          },
+          {
+            code: "KS202EW0036",
+            name: "Irish, Northern Irish and at least one of English/Welsh/Scottish identities (with or without British)",
+            slug: "irish-northern-irish-and-at-least-one-of-english-welsh-scottish-identities-with-or-without-british",
+          },
+          {
+            code: "KS202EW0037",
+            name: "No Irish identity",
+            slug: "no-irish-identity",
+          },
+          {
+            code: "KS202EW0038",
+            name: "All categories: National identity Other",
+            slug: "all-categories-national-identity-other",
+          },
+          {
+            code: "KS202EW0039",
+            name: "Other identities only",
+            slug: "other-identities-only",
+          },
+          {
+            code: "KS202EW0040",
+            name: "Other identities and at least one of English/Welsh/Scottish/Northern Irish/British only",
+            slug: "other-identities-and-at-least-one-of-english-welsh-scottish-northern-irish-british-only",
+          },
+          {
+            code: "KS202EW0041",
+            name: "At least one of English/Welsh/Scottish/Northern Irish/British identities only",
+            slug: "at-least-one-of-english-welsh-scottish-northern-irish-british-identities-only",
+          },
+          {
+            code: "KS202EW0042",
+            name: "English only identity",
+            slug: "english-only-identity",
+          },
+          {
+            code: "KS202EW0043",
+            name: "English and British only identity",
+            slug: "english-and-british-only-identity",
+          },
+          {
+            code: "KS202EW0044",
+            name: "Other English combined background identity",
+            slug: "other-english-combined-background-identity",
+          },
+          {
+            code: "KS202EW0045",
+            name: "No English identity",
+            slug: "no-english-identity",
+          },
+          {
+            code: "KS202EW0046",
+            name: "Welsh only identity",
+            slug: "welsh-only-identity",
+          },
+          {
+            code: "KS202EW0047",
+            name: "Welsh and British only identity",
+            slug: "welsh-and-british-only-identity",
+          },
+          {
+            code: "KS202EW0048",
+            name: "Other Welsh combined background identity",
+            slug: "other-welsh-combined-background-identity",
+          },
+          {
+            code: "KS202EW0049",
+            name: "No Welsh identity",
+            slug: "no-welsh-identity",
+          },
+          {
+            code: "KS202EW0050",
+            name: "Scottish only identity",
+            slug: "scottish-only-identity",
+          },
+          {
+            code: "KS202EW0051",
+            name: "Scottish and British only identity",
+            slug: "scottish-and-british-only-identity",
+          },
+          {
+            code: "KS202EW0052",
+            name: "Other Scottish combined background identity",
+            slug: "other-scottish-combined-background-identity",
+          },
+          {
+            code: "KS202EW0053",
+            name: "No Scottish identity",
+            slug: "no-scottish-identity",
+          },
+          {
+            code: "KS202EW0054",
+            name: "Northern Irish only identity",
+            slug: "northern-irish-only-identity",
+          },
+          {
+            code: "KS202EW0055",
+            name: "Northern Irish and British only identity",
+            slug: "northern-irish-and-british-only-identity",
+          },
+          {
+            code: "KS202EW0056",
+            name: "Other Northern Irish combined background identity",
+            slug: "other-northern-irish-combined-background-identity",
+          },
+          {
+            code: "KS202EW0057",
+            name: "No Northern Irish identity",
+            slug: "no-northern-irish-identity",
+          },
+          {
+            code: "KS202EW0058",
+            name: "British only identity",
+            slug: "british-only-identity",
+          },
+          {
+            code: "KS202EW0059",
+            name: "British and any other identity",
+            slug: "british-and-any-other-identity",
+          },
+          {
+            code: "KS202EW0060",
+            name: "No British identity",
+            slug: "no-british-identity",
+          },
+          {
+            code: "KS202EW0061",
+            name: "Cornish only identity",
+            slug: "cornish-only-identity",
+          },
+          {
+            code: "KS202EW0062",
+            name: "Cornish and British only identity",
+            slug: "cornish-and-british-only-identity",
+          },
+          {
+            code: "KS202EW0063",
+            name: "Cornish and at least one of English/Welsh/Scottish/Northern Irish identities (with or without British)",
+            slug: "cornish-and-at-least-one-of-english-welsh-scottish-northern-irish-identities-with-or-without-british",
+          },
+          {
+            code: "KS202EW0064",
+            name: "No Cornish identity",
+            slug: "no-cornish-identity",
+          },
+          {
+            code: "KS202EW0065",
+            name: "Irish only identity",
+            slug: "irish-only-identity",
+          },
+          {
+            code: "KS202EW0066",
+            name: "Irish and British only identity",
+            slug: "irish-and-british-only-identity",
+          },
+          {
+            code: "KS202EW0067",
+            name: "Irish and Northern Irish only identity",
+            slug: "irish-and-northern-irish-only-identity",
+          },
+          {
+            code: "KS202EW0068",
+            name: "Irish, Northern Irish and British only identity",
+            slug: "irish-northern-irish-and-british-only-identity",
+          },
+          {
+            code: "KS202EW0069",
+            name: "Irish and at least one of English/Welsh/Scottish identities (with or without British)",
+            slug: "irish-and-at-least-one-of-english-welsh-scottish-identities-with-or-without-british",
+          },
+          {
+            code: "KS202EW0070",
+            name: "Irish, Northern Irish and at least one of English/Welsh/Scottish identities (with or without British)",
+            slug: "irish-northern-irish-and-at-least-one-of-english-welsh-scottish-identities-with-or-without-british",
+          },
+          {
+            code: "KS202EW0071",
+            name: "No Irish identity",
+            slug: "no-irish-identity",
+          },
+          {
+            code: "KS202EW0072",
+            name: "Other identities only",
+            slug: "other-identities-only",
+          },
+          {
+            code: "KS202EW0073",
+            name: "Other identities and at least one of English/Welsh/Scottish/Northern Irish/British only",
+            slug: "other-identities-and-at-least-one-of-english-welsh-scottish-northern-irish-british-only",
+          },
+          {
+            code: "KS202EW0074",
+            name: "At least one of English/Welsh/Scottish/Northern Irish/British identities only",
+            slug: "at-least-one-of-english-welsh-scottish-northern-irish-british-identities-only",
+          },
+        ],
+        code: "KS202EW",
+        name: "National identity",
+        slug: "national-identity",
+        desc: "The countries people think of as home.",
+        total: {
+          code: "KS202EW0001",
+          name: "All categories: National identity English",
+          slug: "all-categories-national-identity-english",
+        },
+        units: "People (usual residents)",
+      },
+      {
+        categories: [
+          {
+            code: "QS208EW0002",
+            name: "Christian",
+            slug: "christian",
+          },
+          {
+            code: "QS208EW0003",
+            name: "Buddhist",
+            slug: "buddhist",
+          },
+          {
+            code: "QS208EW0004",
+            name: "Hindu",
+            slug: "hindu",
+          },
+          {
+            code: "QS208EW0005",
+            name: "Jewish",
+            slug: "jewish",
+          },
+          {
+            code: "QS208EW0006",
+            name: "Muslim",
+            slug: "muslim",
+          },
+          {
+            code: "QS208EW0007",
+            name: "Sikh",
+            slug: "sikh",
+          },
+          {
+            code: "QS208EW0008",
+            name: "Other religion",
+            slug: "other-religion",
+          },
+          {
+            code: "QS208EW0009",
+            name: "No religion",
+            slug: "no-religion",
+          },
+          {
+            code: "QS208EW0010",
+            name: "Religion not stated",
+            slug: "religion-not-stated",
+          },
+        ],
+        code: "QS208EW",
+        name: "Religion and beliefs",
+        slug: "religion-and-beliefs",
+        desc: "People's religion and beliefs. ",
+        total: {
+          code: "QS208EW0001",
+          name: "All categories: Religion",
+          slug: "all-categories-religion",
+        },
+        units: "People (usual residents)",
+      },
+      {
+        categories: [
+          {
+            code: "QS203EW0002",
+            name: "Europe: Total",
+            slug: "europe-total",
+          },
+          {
+            code: "QS203EW0003",
+            name: "Europe: United Kingdom: Total",
+            slug: "europe-united-kingdom-total",
+          },
+          {
+            code: "QS203EW0004",
+            name: "Europe: United Kingdom: England",
+            slug: "europe-united-kingdom-england",
+          },
+          {
+            code: "QS203EW0005",
+            name: "Europe: United Kingdom: Northern Ireland",
+            slug: "europe-united-kingdom-northern-ireland",
+          },
+          {
+            code: "QS203EW0006",
+            name: "Europe: United Kingdom: Scotland",
+            slug: "europe-united-kingdom-scotland",
+          },
+          {
+            code: "QS203EW0007",
+            name: "Europe: United Kingdom: Wales",
+            slug: "europe-united-kingdom-wales",
+          },
+          {
+            code: "QS203EW0008",
+            name: "Europe: Great Britain not otherwise specified",
+            slug: "europe-great-britain-not-otherwise-specified",
+          },
+          {
+            code: "QS203EW0009",
+            name: "Europe: United Kingdom not otherwise specified",
+            slug: "europe-united-kingdom-not-otherwise-specified",
+          },
+          {
+            code: "QS203EW0010",
+            name: "Europe: Guernsey",
+            slug: "europe-guernsey",
+          },
+          {
+            code: "QS203EW0011",
+            name: "Europe: Jersey",
+            slug: "europe-jersey",
+          },
+          {
+            code: "QS203EW0012",
+            name: "Europe: Channel Islands not otherwise specified",
+            slug: "europe-channel-islands-not-otherwise-specified",
+          },
+          {
+            code: "QS203EW0013",
+            name: "Europe: Isle of Man",
+            slug: "europe-isle-of-man",
+          },
+          {
+            code: "QS203EW0014",
+            name: "Europe: Ireland",
+            slug: "europe-ireland",
+          },
+          {
+            code: "QS203EW0015",
+            name: "Europe: Other Europe: Total",
+            slug: "europe-other-europe-total",
+          },
+          {
+            code: "QS203EW0016",
+            name: "Europe: Other Europe: EU Countries: Total",
+            slug: "europe-other-europe-eu-countries-total",
+          },
+          {
+            code: "QS203EW0017",
+            name: "Europe: Other Europe: EU countries: Member countries in March 2001: Total",
+            slug: "europe-other-europe-eu-countries-member-countries-in-march-2001-total",
+          },
+          {
+            code: "QS203EW0018",
+            name: "Europe: Other Europe: EU countries: Member countries in March 2001: France",
+            slug: "europe-other-europe-eu-countries-member-countries-in-march-2001-france",
+          },
+          {
+            code: "QS203EW0019",
+            name: "Europe: Other Europe: EU countries: Member countries in March 2001: Germany",
+            slug: "europe-other-europe-eu-countries-member-countries-in-march-2001-germany",
+          },
+          {
+            code: "QS203EW0020",
+            name: "Europe: Other Europe: EU countries: Member countries in March 2001: Italy",
+            slug: "europe-other-europe-eu-countries-member-countries-in-march-2001-italy",
+          },
+          {
+            code: "QS203EW0021",
+            name: "Europe: Other Europe: EU countries: Member countries in March 2001: Portugal",
+            slug: "europe-other-europe-eu-countries-member-countries-in-march-2001-portugal",
+          },
+          {
+            code: "QS203EW0022",
+            name: "Europe: Other Europe: EU countries: Member countries in March 2001: Spain (including Canary Islands)",
+            slug: "europe-other-europe-eu-countries-member-countries-in-march-2001-spain-including-canary-islands",
+          },
+          {
+            code: "QS203EW0023",
+            name: "Europe: Other Europe: EU countries: Member countries in March 2001: Other member countries in March 2001",
+            slug: "europe-other-europe-eu-countries-member-countries-in-march-2001-other-member-countries-in-march-2001",
+          },
+          {
+            code: "QS203EW0024",
+            name: "Europe: Other Europe: EU countries: Accession countries April 2001 to March 2011: Total",
+            slug: "europe-other-europe-eu-countries-accession-countries-april-2001-to-march-2011-total",
+          },
+          {
+            code: "QS203EW0025",
+            name: "Europe: Other Europe: EU countries: Accession countries April 2001 to March 2011: Lithuania",
+            slug: "europe-other-europe-eu-countries-accession-countries-april-2001-to-march-2011-lithuania",
+          },
+          {
+            code: "QS203EW0026",
+            name: "Europe: Other Europe: EU countries: Accession countries April 2001 to March 2011: Poland",
+            slug: "europe-other-europe-eu-countries-accession-countries-april-2001-to-march-2011-poland",
+          },
+          {
+            code: "QS203EW0027",
+            name: "Europe: Other Europe: EU countries: Accession countries April 2001 to March 2011: Romania",
+            slug: "europe-other-europe-eu-countries-accession-countries-april-2001-to-march-2011-romania",
+          },
+          {
+            code: "QS203EW0028",
+            name: "Europe: Other Europe: EU countries: Accession countries April 2001 to March 2011: Other EU accession countries",
+            slug: "europe-other-europe-eu-countries-accession-countries-april-2001-to-march-2011-other-eu-accession-countries",
+          },
+          {
+            code: "QS203EW0029",
+            name: "Europe: Other Europe: Rest of Europe: Total",
+            slug: "europe-other-europe-rest-of-europe-total",
+          },
+          {
+            code: "QS203EW0030",
+            name: "Europe: Other Europe: Rest of Europe: Turkey",
+            slug: "europe-other-europe-rest-of-europe-turkey",
+          },
+          {
+            code: "QS203EW0031",
+            name: "Europe: Other Europe: Rest of Europe: Other Europe",
+            slug: "europe-other-europe-rest-of-europe-other-europe",
+          },
+          {
+            code: "QS203EW0032",
+            name: "Africa: Total",
+            slug: "africa-total",
+          },
+          {
+            code: "QS203EW0033",
+            name: "Africa: North Africa",
+            slug: "africa-north-africa",
+          },
+          {
+            code: "QS203EW0034",
+            name: "Africa: Central and Western Africa: Total",
+            slug: "africa-central-and-western-africa-total",
+          },
+          {
+            code: "QS203EW0035",
+            name: "Africa: Central and Western Africa: Ghana",
+            slug: "africa-central-and-western-africa-ghana",
+          },
+          {
+            code: "QS203EW0036",
+            name: "Africa: Central and Western Africa: Nigeria",
+            slug: "africa-central-and-western-africa-nigeria",
+          },
+          {
+            code: "QS203EW0037",
+            name: "Africa: Central and Western Africa: Other Central and Western Africa",
+            slug: "africa-central-and-western-africa-other-central-and-western-africa",
+          },
+          {
+            code: "QS203EW0038",
+            name: "Africa: South and Eastern Africa: Total",
+            slug: "africa-south-and-eastern-africa-total",
+          },
+          {
+            code: "QS203EW0039",
+            name: "Africa: South and Eastern Africa: Kenya",
+            slug: "africa-south-and-eastern-africa-kenya",
+          },
+          {
+            code: "QS203EW0040",
+            name: "Africa: South and Eastern Africa: Somalia",
+            slug: "africa-south-and-eastern-africa-somalia",
+          },
+          {
+            code: "QS203EW0041",
+            name: "Africa: South and Eastern Africa: South Africa",
+            slug: "africa-south-and-eastern-africa-south-africa",
+          },
+          {
+            code: "QS203EW0042",
+            name: "Africa: South and Eastern Africa: Zimbabwe",
+            slug: "africa-south-and-eastern-africa-zimbabwe",
+          },
+          {
+            code: "QS203EW0043",
+            name: "Africa: South and Eastern Africa: Other South and Eastern Africa",
+            slug: "africa-south-and-eastern-africa-other-south-and-eastern-africa",
+          },
+          {
+            code: "QS203EW0044",
+            name: "Africa: Africa not otherwise specified",
+            slug: "africa-africa-not-otherwise-specified",
+          },
+          {
+            code: "QS203EW0045",
+            name: "Middle East and Asia: Total",
+            slug: "middle-east-and-asia-total",
+          },
+          {
+            code: "QS203EW0046",
+            name: "Middle East and Asia: Middle East: Total",
+            slug: "middle-east-and-asia-middle-east-total",
+          },
+          {
+            code: "QS203EW0047",
+            name: "Middle East and Asia: Middle East: Iran",
+            slug: "middle-east-and-asia-middle-east-iran",
+          },
+          {
+            code: "QS203EW0048",
+            name: "Middle East and Asia: Middle East: Other Middle East",
+            slug: "middle-east-and-asia-middle-east-other-middle-east",
+          },
+          {
+            code: "QS203EW0049",
+            name: "Middle East and Asia: Eastern Asia: Total",
+            slug: "middle-east-and-asia-eastern-asia-total",
+          },
+          {
+            code: "QS203EW0050",
+            name: "Middle East and Asia: Eastern Asia: China",
+            slug: "middle-east-and-asia-eastern-asia-china",
+          },
+          {
+            code: "QS203EW0051",
+            name: "Middle East and Asia: Eastern Asia: Hong Kong (Special Administrative Region of China)",
+            slug: "middle-east-and-asia-eastern-asia-hong-kong-special-administrative-region-of-china",
+          },
+          {
+            code: "QS203EW0052",
+            name: "Middle East and Asia: Eastern Asia: Other Eastern Asia",
+            slug: "middle-east-and-asia-eastern-asia-other-eastern-asia",
+          },
+          {
+            code: "QS203EW0053",
+            name: "Middle East and Asia: Southern Asia: Total",
+            slug: "middle-east-and-asia-southern-asia-total",
+          },
+          {
+            code: "QS203EW0054",
+            name: "Middle East and Asia: Southern Asia: Bangladesh",
+            slug: "middle-east-and-asia-southern-asia-bangladesh",
+          },
+          {
+            code: "QS203EW0055",
+            name: "Middle East and Asia: Southern Asia: India",
+            slug: "middle-east-and-asia-southern-asia-india",
+          },
+          {
+            code: "QS203EW0056",
+            name: "Middle East and Asia: Southern Asia: Pakistan",
+            slug: "middle-east-and-asia-southern-asia-pakistan",
+          },
+          {
+            code: "QS203EW0057",
+            name: "Middle East and Asia: Southern Asia: Sri Lanka",
+            slug: "middle-east-and-asia-southern-asia-sri-lanka",
+          },
+          {
+            code: "QS203EW0058",
+            name: "Middle East and Asia: Southern Asia: Other Southern Asia",
+            slug: "middle-east-and-asia-southern-asia-other-southern-asia",
+          },
+          {
+            code: "QS203EW0059",
+            name: "Middle East and Asia: South-East Asia: Total",
+            slug: "middle-east-and-asia-south-east-asia-total",
+          },
+          {
+            code: "QS203EW0060",
+            name: "Middle East and Asia: South-East Asia: Philippines",
+            slug: "middle-east-and-asia-south-east-asia-philippines",
+          },
+          {
+            code: "QS203EW0061",
+            name: "Middle East and Asia: South-East Asia: Other South-East Asia",
+            slug: "middle-east-and-asia-south-east-asia-other-south-east-asia",
+          },
+          {
+            code: "QS203EW0062",
+            name: "Middle East and Asia: Central Asia",
+            slug: "middle-east-and-asia-central-asia",
+          },
+          {
+            code: "QS203EW0063",
+            name: "The Americas and the Caribbean: Total",
+            slug: "the-americas-and-the-caribbean-total",
+          },
+          {
+            code: "QS203EW0064",
+            name: "The Americas and the Caribbean: North America: Total",
+            slug: "the-americas-and-the-caribbean-north-america-total",
+          },
+          {
+            code: "QS203EW0065",
+            name: "The Americas and the Caribbean: North America: United States",
+            slug: "the-americas-and-the-caribbean-north-america-united-states",
+          },
+          {
+            code: "QS203EW0066",
+            name: "The Americas and the Caribbean: North America: Other North America",
+            slug: "the-americas-and-the-caribbean-north-america-other-north-america",
+          },
+          {
+            code: "QS203EW0067",
+            name: "The Americas and the Caribbean: Central America",
+            slug: "the-americas-and-the-caribbean-central-america",
+          },
+          {
+            code: "QS203EW0068",
+            name: "The Americas and the Caribbean: South America",
+            slug: "the-americas-and-the-caribbean-south-america",
+          },
+          {
+            code: "QS203EW0069",
+            name: "The Americas and the Caribbean: The Caribbean: Total",
+            slug: "the-americas-and-the-caribbean-the-caribbean-total",
+          },
+          {
+            code: "QS203EW0070",
+            name: "The Americas and the Caribbean: The Caribbean: Jamaica",
+            slug: "the-americas-and-the-caribbean-the-caribbean-jamaica",
+          },
+          {
+            code: "QS203EW0071",
+            name: "The Americas and the Caribbean: The Caribbean: Other Caribbean",
+            slug: "the-americas-and-the-caribbean-the-caribbean-other-caribbean",
+          },
+          {
+            code: "QS203EW0072",
+            name: "Antarctica and Oceania: Total",
+            slug: "antarctica-and-oceania-total",
+          },
+          {
+            code: "QS203EW0073",
+            name: "Antarctica and Oceania: Antarctica",
+            slug: "antarctica-and-oceania-antarctica",
+          },
+          {
+            code: "QS203EW0074",
+            name: "Antarctica and Oceania: Australasia: Total",
+            slug: "antarctica-and-oceania-australasia-total",
+          },
+          {
+            code: "QS203EW0075",
+            name: "Antarctica and Oceania: Australasia: Australia",
+            slug: "antarctica-and-oceania-australasia-australia",
+          },
+          {
+            code: "QS203EW0076",
+            name: "Antarctica and Oceania: Australasia: Other Australasia",
+            slug: "antarctica-and-oceania-australasia-other-australasia",
+          },
+          {
+            code: "QS203EW0077",
+            name: "Antarctica and Oceania: Other Oceania",
+            slug: "antarctica-and-oceania-other-oceania",
+          },
+          {
+            code: "QS203EW0078",
+            name: "Other",
+            slug: "other",
+          },
+        ],
+        code: "QS203EW",
+        name: "Place of birth",
+        slug: "place-of-birth",
+        desc: "People born in or outside the UK.",
+        total: {
+          code: "QS203EW0001",
+          name: "All categories: Country of birth",
+          slug: "all-categories-country-of-birth",
+        },
+        units: "People (usual residents)",
+      },
+      {
+        categories: [
+          {
+            code: "QS803EW0002",
+            name: "Born in the UK",
+            slug: "born-in-the-uk",
+          },
+          {
+            code: "QS803EW0003",
+            name: "Resident in UK: Less than 2 years",
+            slug: "resident-in-uk-less-than-2-years",
+          },
+          {
+            code: "QS803EW0004",
+            name: "Resident in UK: 2 years or more but less than 5 years",
+            slug: "resident-in-uk-2-years-or-more-but-less-than-5-years",
+          },
+          {
+            code: "QS803EW0005",
+            name: "Resident in UK: 5 years or more but less than 10 years",
+            slug: "resident-in-uk-5-years-or-more-but-less-than-10-years",
+          },
+          {
+            code: "QS803EW0006",
+            name: "Resident in UK: 10 years or more",
+            slug: "resident-in-uk-10-years-or-more",
+          },
+        ],
+        code: "QS803EW",
+        name: "Length of time people have lived in the uk",
+        slug: "length-of-time-people-have-lived-in-the-uk",
+        desc: "People born or have moved to the UK,",
+        total: {
+          code: "QS803EW0001",
+          name: "All categories: Length of residence in the UK",
+          slug: "all-categories-length-of-residence-in-the-uk",
+        },
+        units: "People (usual residents)",
+      },
+    ],
   },
   {
-      "code": "Population",
-      "name": "Population",
-      "slug": "population",
-      "desc": "Residents and their living arrangements.",
-      "tables": [
+    code: "Population",
+    name: "Population",
+    slug: "population",
+    desc: "Residents and their living arrangements.",
+    tables: [
+      {
+        categories: [
           {
-              "categories": [
-                  {
-                      "code": "QS104EW0002",
-                      "name": "Males",
-                      "slug": "males"
-                  },
-                  {
-                      "code": "QS104EW0003",
-                      "name": "Females",
-                      "slug": "females"
-                  }
-              ],
-              "code": "QS104EW",
-              "name": "Sex",
-              "slug": "sex",
-              "desc": "The biological sex recorded by the person completing the census.",
-              "total": {
-                  "code": "QS104EW0001",
-                  "name": "All categories: Sex",
-                  "slug": "all-categories-sex"
-              },
-              "units": "People (usual residents)"
+            code: "QS104EW0002",
+            name: "Males",
+            slug: "males",
           },
           {
-              "categories": [
-                  {
-                      "code": "KS102EW0002",
-                      "name": "Age 0 to 4",
-                      "slug": "age-0-to-4"
-                  },
-                  {
-                      "code": "KS102EW0003",
-                      "name": "Age 5 to 7",
-                      "slug": "age-5-to-7"
-                  },
-                  {
-                      "code": "KS102EW0004",
-                      "name": "Age 8 to 9",
-                      "slug": "age-8-to-9"
-                  },
-                  {
-                      "code": "KS102EW0005",
-                      "name": "Age 10 to 14",
-                      "slug": "age-10-to-14"
-                  },
-                  {
-                      "code": "KS102EW0006",
-                      "name": "Age 15",
-                      "slug": "age-15"
-                  },
-                  {
-                      "code": "KS102EW0007",
-                      "name": "Age 16 to 17",
-                      "slug": "age-16-to-17"
-                  },
-                  {
-                      "code": "KS102EW0008",
-                      "name": "Age 18 to 19",
-                      "slug": "age-18-to-19"
-                  },
-                  {
-                      "code": "KS102EW0009",
-                      "name": "Age 20 to 24",
-                      "slug": "age-20-to-24"
-                  },
-                  {
-                      "code": "KS102EW0010",
-                      "name": "Age 25 to 29",
-                      "slug": "age-25-to-29"
-                  },
-                  {
-                      "code": "KS102EW0011",
-                      "name": "Age 30 to 44",
-                      "slug": "age-30-to-44"
-                  },
-                  {
-                      "code": "KS102EW0012",
-                      "name": "Age 45 to 59",
-                      "slug": "age-45-to-59"
-                  },
-                  {
-                      "code": "KS102EW0013",
-                      "name": "Age 60 to 64",
-                      "slug": "age-60-to-64"
-                  },
-                  {
-                      "code": "KS102EW0014",
-                      "name": "Age 65 to 74",
-                      "slug": "age-65-to-74"
-                  },
-                  {
-                      "code": "KS102EW0015",
-                      "name": "Age 75 to 84",
-                      "slug": "age-75-to-84"
-                  },
-                  {
-                      "code": "KS102EW0016",
-                      "name": "Age 85 to 89",
-                      "slug": "age-85-to-89"
-                  },
-                  {
-                      "code": "KS102EW0017",
-                      "name": "Age 90 and over",
-                      "slug": "age-90-and-over"
-                  },
-                  {
-                      "code": "KS102EW0018",
-                      "name": "Mean age",
-                      "slug": "mean-age"
-                  },
-                  {
-                      "code": "KS102EW0019",
-                      "name": "Median age",
-                      "slug": "median-age"
-                  },
-                  {
-                      "code": "KS102EW0020",
-                      "name": "Age 0 to 4",
-                      "slug": "age-0-to-4"
-                  },
-                  {
-                      "code": "KS102EW0021",
-                      "name": "Age 5 to 7",
-                      "slug": "age-5-to-7"
-                  },
-                  {
-                      "code": "KS102EW0022",
-                      "name": "Age 8 to 9",
-                      "slug": "age-8-to-9"
-                  },
-                  {
-                      "code": "KS102EW0023",
-                      "name": "Age 10 to 14",
-                      "slug": "age-10-to-14"
-                  },
-                  {
-                      "code": "KS102EW0024",
-                      "name": "Age 15",
-                      "slug": "age-15"
-                  },
-                  {
-                      "code": "KS102EW0025",
-                      "name": "Age 16 to 17",
-                      "slug": "age-16-to-17"
-                  },
-                  {
-                      "code": "KS102EW0026",
-                      "name": "Age 18 to 19",
-                      "slug": "age-18-to-19"
-                  },
-                  {
-                      "code": "KS102EW0027",
-                      "name": "Age 20 to 24",
-                      "slug": "age-20-to-24"
-                  },
-                  {
-                      "code": "KS102EW0028",
-                      "name": "Age 25 to 29",
-                      "slug": "age-25-to-29"
-                  },
-                  {
-                      "code": "KS102EW0029",
-                      "name": "Age 30 to 44",
-                      "slug": "age-30-to-44"
-                  },
-                  {
-                      "code": "KS102EW0030",
-                      "name": "Age 45 to 59",
-                      "slug": "age-45-to-59"
-                  },
-                  {
-                      "code": "KS102EW0031",
-                      "name": "Age 60 to 64",
-                      "slug": "age-60-to-64"
-                  },
-                  {
-                      "code": "KS102EW0032",
-                      "name": "Age 65 to 74",
-                      "slug": "age-65-to-74"
-                  },
-                  {
-                      "code": "KS102EW0033",
-                      "name": "Age 75 to 84",
-                      "slug": "age-75-to-84"
-                  },
-                  {
-                      "code": "KS102EW0034",
-                      "name": "Age 85 to 89",
-                      "slug": "age-85-to-89"
-                  },
-                  {
-                      "code": "KS102EW0035",
-                      "name": "Age 90 and over",
-                      "slug": "age-90-and-over"
-                  }
-              ],
-              "code": "KS102EW",
-              "name": "Age",
-              "slug": "age",
-              "desc": "The age of a person on Census Day, 21 March 2021.",
-              "total": {
-                  "code": "KS102EW0001",
-                  "name": "All categories: Age",
-                  "slug": "all-categories-age"
-              },
-              "units": "People (usual residents)"
+            code: "QS104EW0003",
+            name: "Females",
+            slug: "females",
+          },
+        ],
+        code: "QS104EW",
+        name: "Sex",
+        slug: "sex",
+        desc: "The biological sex recorded by the person completing the census.",
+        total: {
+          code: "QS104EW0001",
+          name: "All categories: Sex",
+          slug: "all-categories-sex",
+        },
+        units: "People (usual residents)",
+      },
+      {
+        categories: [
+          {
+            code: "KS102EW0002",
+            name: "Age 0 to 4",
+            slug: "age-0-to-4",
           },
           {
-              "categories": [
-                  {
-                      "code": "QS113EW0002",
-                      "name": "One person household: Total",
-                      "slug": "one-person-household-total"
-                  },
-                  {
-                      "code": "QS113EW0003",
-                      "name": "One person household: Aged 65 and over",
-                      "slug": "one-person-household-aged-65-and-over"
-                  },
-                  {
-                      "code": "QS113EW0004",
-                      "name": "One person household: Other",
-                      "slug": "one-person-household-other"
-                  },
-                  {
-                      "code": "QS113EW0005",
-                      "name": "One family only: Total",
-                      "slug": "one-family-only-total"
-                  },
-                  {
-                      "code": "QS113EW0006",
-                      "name": "One family only: All aged 65 and over",
-                      "slug": "one-family-only-all-aged-65-and-over"
-                  },
-                  {
-                      "code": "QS113EW0007",
-                      "name": "One family only: Married couple: Total",
-                      "slug": "one-family-only-married-couple-total"
-                  },
-                  {
-                      "code": "QS113EW0008",
-                      "name": "One family only: Married couple: No children",
-                      "slug": "one-family-only-married-couple-no-children"
-                  },
-                  {
-                      "code": "QS113EW0009",
-                      "name": "One family only: Married couple: One dependent child",
-                      "slug": "one-family-only-married-couple-one-dependent-child"
-                  },
-                  {
-                      "code": "QS113EW0010",
-                      "name": "One family only: Married couple: Two or more dependent children",
-                      "slug": "one-family-only-married-couple-two-or-more-dependent-children"
-                  },
-                  {
-                      "code": "QS113EW0011",
-                      "name": "One family only: Married couple: All children non-dependent",
-                      "slug": "one-family-only-married-couple-all-children-non-dependent"
-                  },
-                  {
-                      "code": "QS113EW0012",
-                      "name": "One family only: Same-sex civil partnership couple: Total",
-                      "slug": "one-family-only-same-sex-civil-partnership-couple-total"
-                  },
-                  {
-                      "code": "QS113EW0013",
-                      "name": "One family only: Same-sex civil partnership couple: No children",
-                      "slug": "one-family-only-same-sex-civil-partnership-couple-no-children"
-                  },
-                  {
-                      "code": "QS113EW0014",
-                      "name": "One family only: Same-sex civil partnership couple: One dependent child",
-                      "slug": "one-family-only-same-sex-civil-partnership-couple-one-dependent-child"
-                  },
-                  {
-                      "code": "QS113EW0015",
-                      "name": "One family only: Same-sex civil partnership couple: Two or more dependent children",
-                      "slug": "one-family-only-same-sex-civil-partnership-couple-two-or-more-dependent-children"
-                  },
-                  {
-                      "code": "QS113EW0016",
-                      "name": "One family only: Same-sex civil partnership couple: All children non-dependent",
-                      "slug": "one-family-only-same-sex-civil-partnership-couple-all-children-non-dependent"
-                  },
-                  {
-                      "code": "QS113EW0017",
-                      "name": "One family only: Cohabiting couple: Total",
-                      "slug": "one-family-only-cohabiting-couple-total"
-                  },
-                  {
-                      "code": "QS113EW0018",
-                      "name": "One family only: Cohabiting couple: No children",
-                      "slug": "one-family-only-cohabiting-couple-no-children"
-                  },
-                  {
-                      "code": "QS113EW0019",
-                      "name": "One family only: Cohabiting couple: One dependent child",
-                      "slug": "one-family-only-cohabiting-couple-one-dependent-child"
-                  },
-                  {
-                      "code": "QS113EW0020",
-                      "name": "One family only: Cohabiting couple: Two or more dependent children",
-                      "slug": "one-family-only-cohabiting-couple-two-or-more-dependent-children"
-                  },
-                  {
-                      "code": "QS113EW0021",
-                      "name": "One family only: Cohabiting couple: All children non-dependent",
-                      "slug": "one-family-only-cohabiting-couple-all-children-non-dependent"
-                  },
-                  {
-                      "code": "QS113EW0022",
-                      "name": "One family only: Lone parent: Total",
-                      "slug": "one-family-only-lone-parent-total"
-                  },
-                  {
-                      "code": "QS113EW0023",
-                      "name": "One family only: Lone parent: One dependent child",
-                      "slug": "one-family-only-lone-parent-one-dependent-child"
-                  },
-                  {
-                      "code": "QS113EW0024",
-                      "name": "One family only: Lone parent: Two or more dependent children",
-                      "slug": "one-family-only-lone-parent-two-or-more-dependent-children"
-                  },
-                  {
-                      "code": "QS113EW0025",
-                      "name": "One family only: Lone parent: All children non-dependent",
-                      "slug": "one-family-only-lone-parent-all-children-non-dependent"
-                  },
-                  {
-                      "code": "QS113EW0026",
-                      "name": "Other household types: Total",
-                      "slug": "other-household-types-total"
-                  },
-                  {
-                      "code": "QS113EW0027",
-                      "name": "Other household types: With one dependent child",
-                      "slug": "other-household-types-with-one-dependent-child"
-                  },
-                  {
-                      "code": "QS113EW0028",
-                      "name": "Other household types: With two or more dependent children",
-                      "slug": "other-household-types-with-two-or-more-dependent-children"
-                  },
-                  {
-                      "code": "QS113EW0029",
-                      "name": "Other household types: All full-time students",
-                      "slug": "other-household-types-all-full-time-students"
-                  },
-                  {
-                      "code": "QS113EW0030",
-                      "name": "Other household types: All aged 65 and over",
-                      "slug": "other-household-types-all-aged-65-and-over"
-                  },
-                  {
-                      "code": "QS113EW0031",
-                      "name": "Other household types: Other",
-                      "slug": "other-household-types-other"
-                  }
-              ],
-              "code": "QS113EW",
-              "name": "Marital status",
-              "slug": "marital-status",
-              "desc": "People married of in civil partnerships.",
-              "total": {
-                  "code": "QS113EW0001",
-                  "name": "All categories: Household composition",
-                  "slug": "all-categories-household-composition"
-              },
-              "units": "Households"
+            code: "KS102EW0003",
+            name: "Age 5 to 7",
+            slug: "age-5-to-7",
           },
           {
-              "categories": [
-                  {
-                      "code": "QS112EW0002",
-                      "name": "One person household: Total",
-                      "slug": "one-person-household-total"
-                  },
-                  {
-                      "code": "QS112EW0003",
-                      "name": "One person household: Aged 65 and over",
-                      "slug": "one-person-household-aged-65-and-over"
-                  },
-                  {
-                      "code": "QS112EW0004",
-                      "name": "One person household: Other",
-                      "slug": "one-person-household-other"
-                  },
-                  {
-                      "code": "QS112EW0005",
-                      "name": "One family only: Total",
-                      "slug": "one-family-only-total"
-                  },
-                  {
-                      "code": "QS112EW0006",
-                      "name": "One family only: All aged 65 and over",
-                      "slug": "one-family-only-all-aged-65-and-over"
-                  },
-                  {
-                      "code": "QS112EW0007",
-                      "name": "One family only: Married couple: Total",
-                      "slug": "one-family-only-married-couple-total"
-                  },
-                  {
-                      "code": "QS112EW0008",
-                      "name": "One family only: Married couple: No children",
-                      "slug": "one-family-only-married-couple-no-children"
-                  },
-                  {
-                      "code": "QS112EW0009",
-                      "name": "One family only: Married couple: One dependent child",
-                      "slug": "one-family-only-married-couple-one-dependent-child"
-                  },
-                  {
-                      "code": "QS112EW0010",
-                      "name": "One family only: Married couple: Two or more dependent children",
-                      "slug": "one-family-only-married-couple-two-or-more-dependent-children"
-                  },
-                  {
-                      "code": "QS112EW0011",
-                      "name": "One family only: Married couple: All children non-dependent",
-                      "slug": "one-family-only-married-couple-all-children-non-dependent"
-                  },
-                  {
-                      "code": "QS112EW0012",
-                      "name": "One family only: Same-sex civil partnership couple: Total",
-                      "slug": "one-family-only-same-sex-civil-partnership-couple-total"
-                  },
-                  {
-                      "code": "QS112EW0013",
-                      "name": "One family only: Same-sex civil partnership couple: No children",
-                      "slug": "one-family-only-same-sex-civil-partnership-couple-no-children"
-                  },
-                  {
-                      "code": "QS112EW0014",
-                      "name": "One family only: Same-sex civil partnership couple: One dependent child",
-                      "slug": "one-family-only-same-sex-civil-partnership-couple-one-dependent-child"
-                  },
-                  {
-                      "code": "QS112EW0015",
-                      "name": "One family only: Same-sex civil partnership couple: Two or more dependent children",
-                      "slug": "one-family-only-same-sex-civil-partnership-couple-two-or-more-dependent-children"
-                  },
-                  {
-                      "code": "QS112EW0016",
-                      "name": "One family only: Same-sex civil partnership couple: All children non-dependent",
-                      "slug": "one-family-only-same-sex-civil-partnership-couple-all-children-non-dependent"
-                  },
-                  {
-                      "code": "QS112EW0017",
-                      "name": "One family only: Cohabiting couple: Total",
-                      "slug": "one-family-only-cohabiting-couple-total"
-                  },
-                  {
-                      "code": "QS112EW0018",
-                      "name": "One family only: Cohabiting couple: No children",
-                      "slug": "one-family-only-cohabiting-couple-no-children"
-                  },
-                  {
-                      "code": "QS112EW0019",
-                      "name": "One family only: Cohabiting couple: One dependent child",
-                      "slug": "one-family-only-cohabiting-couple-one-dependent-child"
-                  },
-                  {
-                      "code": "QS112EW0020",
-                      "name": "One family only: Cohabiting couple: Two or more dependent children",
-                      "slug": "one-family-only-cohabiting-couple-two-or-more-dependent-children"
-                  },
-                  {
-                      "code": "QS112EW0021",
-                      "name": "One family only: Cohabiting couple: All children non-dependent",
-                      "slug": "one-family-only-cohabiting-couple-all-children-non-dependent"
-                  },
-                  {
-                      "code": "QS112EW0022",
-                      "name": "One family only: Lone parent: Total",
-                      "slug": "one-family-only-lone-parent-total"
-                  },
-                  {
-                      "code": "QS112EW0023",
-                      "name": "One family only: Lone parent: One dependent child",
-                      "slug": "one-family-only-lone-parent-one-dependent-child"
-                  },
-                  {
-                      "code": "QS112EW0024",
-                      "name": "One family only: Lone parent: Two or more dependent children",
-                      "slug": "one-family-only-lone-parent-two-or-more-dependent-children"
-                  },
-                  {
-                      "code": "QS112EW0025",
-                      "name": "One family only: Lone parent: All children non-dependent",
-                      "slug": "one-family-only-lone-parent-all-children-non-dependent"
-                  },
-                  {
-                      "code": "QS112EW0026",
-                      "name": "Other household types: Total",
-                      "slug": "other-household-types-total"
-                  },
-                  {
-                      "code": "QS112EW0027",
-                      "name": "Other household types: With one dependent child",
-                      "slug": "other-household-types-with-one-dependent-child"
-                  },
-                  {
-                      "code": "QS112EW0028",
-                      "name": "Other household types: With two or more dependent children",
-                      "slug": "other-household-types-with-two-or-more-dependent-children"
-                  },
-                  {
-                      "code": "QS112EW0029",
-                      "name": "Other household types: All full-time students",
-                      "slug": "other-household-types-all-full-time-students"
-                  },
-                  {
-                      "code": "QS112EW0030",
-                      "name": "Other household types: All aged 65 and over",
-                      "slug": "other-household-types-all-aged-65-and-over"
-                  },
-                  {
-                      "code": "QS112EW0031",
-                      "name": "Other household types: Other",
-                      "slug": "other-household-types-other"
-                  }
-              ],
-              "code": "QS112EW",
-              "name": "Families living in the same home",
-              "slug": "families-living-in-the-same-home",
-              "desc": "Types of families living in the same home.",
-              "total": {
-                  "code": "QS112EW0001",
-                  "name": "All categories: Household composition",
-                  "slug": "all-categories-household-composition"
-              },
-              "units": "Households"
+            code: "KS102EW0004",
+            name: "Age 8 to 9",
+            slug: "age-8-to-9",
           },
           {
-              "categories": [
-                  {
-                      "code": "QS101EW0002",
-                      "name": "Lives in a household",
-                      "slug": "lives-in-a-household"
-                  },
-                  {
-                      "code": "QS101EW0003",
-                      "name": "Lives in a communal establishment",
-                      "slug": "lives-in-a-communal-establishment"
-                  },
-                  {
-                      "code": "QS101EW0004",
-                      "name": "Communal establishments with persons sleeping rough identified",
-                      "slug": "communal-establishments-with-persons-sleeping-rough-identified"
-                  }
-              ],
-              "code": "QS101EW",
-              "name": "Residence type",
-              "slug": "residence-type",
-              "desc": "Families and other groups living in the same home or communal establishment.",
-              "total": {
-                  "code": "QS101EW0001",
-                  "name": "All categories: Residence type",
-                  "slug": "all-categories-residence-type"
-              },
-              "units": "People (usual residents)"
+            code: "KS102EW0005",
+            name: "Age 10 to 14",
+            slug: "age-10-to-14",
           },
           {
-              "categories": [
-                  {
-                      "code": "KS206EW0002",
-                      "name": "All people aged 16 and over in household have English as a main language (English or Welsh in Wales)",
-                      "slug": "all-people-aged-16-and-over-in-household-have-english-as-a-main-language-english-or-welsh-in-wales"
-                  },
-                  {
-                      "code": "KS206EW0003",
-                      "name": "At least one but not all people aged 16 and over in household have English as a main language (English or Welsh in Wales)",
-                      "slug": "at-least-one-but-not-all-people-aged-16-and-over-in-household-have-english-as-a-main-language-english-or-welsh-in-wales"
-                  },
-                  {
-                      "code": "KS206EW0004",
-                      "name": "No people aged 16 and over in household but at least one person aged 3 to 15 has English as a main language (English or Welsh in Wales)",
-                      "slug": "no-people-aged-16-and-over-in-household-but-at-least-one-person-aged-3-to-15-has-english-as-a-main-language-english-or-welsh-in-wales"
-                  },
-                  {
-                      "code": "KS206EW0005",
-                      "name": "No people in household have English as a main language (English or Welsh in Wales)",
-                      "slug": "no-people-in-household-have-english-as-a-main-language-english-or-welsh-in-wales"
-                  },
-                  {
-                      "code": "KS206EW0006",
-                      "name": "All people aged 16 and over in household have English as a main language (English or Welsh in Wales)",
-                      "slug": "all-people-aged-16-and-over-in-household-have-english-as-a-main-language-english-or-welsh-in-wales"
-                  },
-                  {
-                      "code": "KS206EW0007",
-                      "name": "At least one but not all people aged 16 and over in household have English as a main language (English or Welsh in Wales)",
-                      "slug": "at-least-one-but-not-all-people-aged-16-and-over-in-household-have-english-as-a-main-language-english-or-welsh-in-wales"
-                  },
-                  {
-                      "code": "KS206EW0008",
-                      "name": "No people aged 16 and over in household but at least one person aged 3 to 15 has English as a main language (English or Welsh in Wales)",
-                      "slug": "no-people-aged-16-and-over-in-household-but-at-least-one-person-aged-3-to-15-has-english-as-a-main-language-english-or-welsh-in-wales"
-                  },
-                  {
-                      "code": "KS206EW0009",
-                      "name": "No people in household have English as a main language (English or Welsh in Wales)",
-                      "slug": "no-people-in-household-have-english-as-a-main-language-english-or-welsh-in-wales"
-                  }
-              ],
-              "code": "KS206EW",
-              "name": "Language",
-              "slug": "language",
-              "desc": "English is the main household language.",
-              "total": {
-                  "code": "KS206EW0001",
-                  "name": "All categories: English as a household language",
-                  "slug": "all-categories-english-as-a-household-language"
-              },
-              "units": "Households"
-          }
-      ]
+            code: "KS102EW0006",
+            name: "Age 15",
+            slug: "age-15",
+          },
+          {
+            code: "KS102EW0007",
+            name: "Age 16 to 17",
+            slug: "age-16-to-17",
+          },
+          {
+            code: "KS102EW0008",
+            name: "Age 18 to 19",
+            slug: "age-18-to-19",
+          },
+          {
+            code: "KS102EW0009",
+            name: "Age 20 to 24",
+            slug: "age-20-to-24",
+          },
+          {
+            code: "KS102EW0010",
+            name: "Age 25 to 29",
+            slug: "age-25-to-29",
+          },
+          {
+            code: "KS102EW0011",
+            name: "Age 30 to 44",
+            slug: "age-30-to-44",
+          },
+          {
+            code: "KS102EW0012",
+            name: "Age 45 to 59",
+            slug: "age-45-to-59",
+          },
+          {
+            code: "KS102EW0013",
+            name: "Age 60 to 64",
+            slug: "age-60-to-64",
+          },
+          {
+            code: "KS102EW0014",
+            name: "Age 65 to 74",
+            slug: "age-65-to-74",
+          },
+          {
+            code: "KS102EW0015",
+            name: "Age 75 to 84",
+            slug: "age-75-to-84",
+          },
+          {
+            code: "KS102EW0016",
+            name: "Age 85 to 89",
+            slug: "age-85-to-89",
+          },
+          {
+            code: "KS102EW0017",
+            name: "Age 90 and over",
+            slug: "age-90-and-over",
+          },
+          {
+            code: "KS102EW0018",
+            name: "Mean age",
+            slug: "mean-age",
+          },
+          {
+            code: "KS102EW0019",
+            name: "Median age",
+            slug: "median-age",
+          },
+          {
+            code: "KS102EW0020",
+            name: "Age 0 to 4",
+            slug: "age-0-to-4",
+          },
+          {
+            code: "KS102EW0021",
+            name: "Age 5 to 7",
+            slug: "age-5-to-7",
+          },
+          {
+            code: "KS102EW0022",
+            name: "Age 8 to 9",
+            slug: "age-8-to-9",
+          },
+          {
+            code: "KS102EW0023",
+            name: "Age 10 to 14",
+            slug: "age-10-to-14",
+          },
+          {
+            code: "KS102EW0024",
+            name: "Age 15",
+            slug: "age-15",
+          },
+          {
+            code: "KS102EW0025",
+            name: "Age 16 to 17",
+            slug: "age-16-to-17",
+          },
+          {
+            code: "KS102EW0026",
+            name: "Age 18 to 19",
+            slug: "age-18-to-19",
+          },
+          {
+            code: "KS102EW0027",
+            name: "Age 20 to 24",
+            slug: "age-20-to-24",
+          },
+          {
+            code: "KS102EW0028",
+            name: "Age 25 to 29",
+            slug: "age-25-to-29",
+          },
+          {
+            code: "KS102EW0029",
+            name: "Age 30 to 44",
+            slug: "age-30-to-44",
+          },
+          {
+            code: "KS102EW0030",
+            name: "Age 45 to 59",
+            slug: "age-45-to-59",
+          },
+          {
+            code: "KS102EW0031",
+            name: "Age 60 to 64",
+            slug: "age-60-to-64",
+          },
+          {
+            code: "KS102EW0032",
+            name: "Age 65 to 74",
+            slug: "age-65-to-74",
+          },
+          {
+            code: "KS102EW0033",
+            name: "Age 75 to 84",
+            slug: "age-75-to-84",
+          },
+          {
+            code: "KS102EW0034",
+            name: "Age 85 to 89",
+            slug: "age-85-to-89",
+          },
+          {
+            code: "KS102EW0035",
+            name: "Age 90 and over",
+            slug: "age-90-and-over",
+          },
+        ],
+        code: "KS102EW",
+        name: "Age",
+        slug: "age",
+        desc: "The age of a person on Census Day, 21 March 2021.",
+        total: {
+          code: "KS102EW0001",
+          name: "All categories: Age",
+          slug: "all-categories-age",
+        },
+        units: "People (usual residents)",
+      },
+      {
+        categories: [
+          {
+            code: "QS113EW0002",
+            name: "One person household: Total",
+            slug: "one-person-household-total",
+          },
+          {
+            code: "QS113EW0003",
+            name: "One person household: Aged 65 and over",
+            slug: "one-person-household-aged-65-and-over",
+          },
+          {
+            code: "QS113EW0004",
+            name: "One person household: Other",
+            slug: "one-person-household-other",
+          },
+          {
+            code: "QS113EW0005",
+            name: "One family only: Total",
+            slug: "one-family-only-total",
+          },
+          {
+            code: "QS113EW0006",
+            name: "One family only: All aged 65 and over",
+            slug: "one-family-only-all-aged-65-and-over",
+          },
+          {
+            code: "QS113EW0007",
+            name: "One family only: Married couple: Total",
+            slug: "one-family-only-married-couple-total",
+          },
+          {
+            code: "QS113EW0008",
+            name: "One family only: Married couple: No children",
+            slug: "one-family-only-married-couple-no-children",
+          },
+          {
+            code: "QS113EW0009",
+            name: "One family only: Married couple: One dependent child",
+            slug: "one-family-only-married-couple-one-dependent-child",
+          },
+          {
+            code: "QS113EW0010",
+            name: "One family only: Married couple: Two or more dependent children",
+            slug: "one-family-only-married-couple-two-or-more-dependent-children",
+          },
+          {
+            code: "QS113EW0011",
+            name: "One family only: Married couple: All children non-dependent",
+            slug: "one-family-only-married-couple-all-children-non-dependent",
+          },
+          {
+            code: "QS113EW0012",
+            name: "One family only: Same-sex civil partnership couple: Total",
+            slug: "one-family-only-same-sex-civil-partnership-couple-total",
+          },
+          {
+            code: "QS113EW0013",
+            name: "One family only: Same-sex civil partnership couple: No children",
+            slug: "one-family-only-same-sex-civil-partnership-couple-no-children",
+          },
+          {
+            code: "QS113EW0014",
+            name: "One family only: Same-sex civil partnership couple: One dependent child",
+            slug: "one-family-only-same-sex-civil-partnership-couple-one-dependent-child",
+          },
+          {
+            code: "QS113EW0015",
+            name: "One family only: Same-sex civil partnership couple: Two or more dependent children",
+            slug: "one-family-only-same-sex-civil-partnership-couple-two-or-more-dependent-children",
+          },
+          {
+            code: "QS113EW0016",
+            name: "One family only: Same-sex civil partnership couple: All children non-dependent",
+            slug: "one-family-only-same-sex-civil-partnership-couple-all-children-non-dependent",
+          },
+          {
+            code: "QS113EW0017",
+            name: "One family only: Cohabiting couple: Total",
+            slug: "one-family-only-cohabiting-couple-total",
+          },
+          {
+            code: "QS113EW0018",
+            name: "One family only: Cohabiting couple: No children",
+            slug: "one-family-only-cohabiting-couple-no-children",
+          },
+          {
+            code: "QS113EW0019",
+            name: "One family only: Cohabiting couple: One dependent child",
+            slug: "one-family-only-cohabiting-couple-one-dependent-child",
+          },
+          {
+            code: "QS113EW0020",
+            name: "One family only: Cohabiting couple: Two or more dependent children",
+            slug: "one-family-only-cohabiting-couple-two-or-more-dependent-children",
+          },
+          {
+            code: "QS113EW0021",
+            name: "One family only: Cohabiting couple: All children non-dependent",
+            slug: "one-family-only-cohabiting-couple-all-children-non-dependent",
+          },
+          {
+            code: "QS113EW0022",
+            name: "One family only: Lone parent: Total",
+            slug: "one-family-only-lone-parent-total",
+          },
+          {
+            code: "QS113EW0023",
+            name: "One family only: Lone parent: One dependent child",
+            slug: "one-family-only-lone-parent-one-dependent-child",
+          },
+          {
+            code: "QS113EW0024",
+            name: "One family only: Lone parent: Two or more dependent children",
+            slug: "one-family-only-lone-parent-two-or-more-dependent-children",
+          },
+          {
+            code: "QS113EW0025",
+            name: "One family only: Lone parent: All children non-dependent",
+            slug: "one-family-only-lone-parent-all-children-non-dependent",
+          },
+          {
+            code: "QS113EW0026",
+            name: "Other household types: Total",
+            slug: "other-household-types-total",
+          },
+          {
+            code: "QS113EW0027",
+            name: "Other household types: With one dependent child",
+            slug: "other-household-types-with-one-dependent-child",
+          },
+          {
+            code: "QS113EW0028",
+            name: "Other household types: With two or more dependent children",
+            slug: "other-household-types-with-two-or-more-dependent-children",
+          },
+          {
+            code: "QS113EW0029",
+            name: "Other household types: All full-time students",
+            slug: "other-household-types-all-full-time-students",
+          },
+          {
+            code: "QS113EW0030",
+            name: "Other household types: All aged 65 and over",
+            slug: "other-household-types-all-aged-65-and-over",
+          },
+          {
+            code: "QS113EW0031",
+            name: "Other household types: Other",
+            slug: "other-household-types-other",
+          },
+        ],
+        code: "QS113EW",
+        name: "Marital status",
+        slug: "marital-status",
+        desc: "People married of in civil partnerships.",
+        total: {
+          code: "QS113EW0001",
+          name: "All categories: Household composition",
+          slug: "all-categories-household-composition",
+        },
+        units: "Households",
+      },
+      {
+        categories: [
+          {
+            code: "QS112EW0002",
+            name: "One person household: Total",
+            slug: "one-person-household-total",
+          },
+          {
+            code: "QS112EW0003",
+            name: "One person household: Aged 65 and over",
+            slug: "one-person-household-aged-65-and-over",
+          },
+          {
+            code: "QS112EW0004",
+            name: "One person household: Other",
+            slug: "one-person-household-other",
+          },
+          {
+            code: "QS112EW0005",
+            name: "One family only: Total",
+            slug: "one-family-only-total",
+          },
+          {
+            code: "QS112EW0006",
+            name: "One family only: All aged 65 and over",
+            slug: "one-family-only-all-aged-65-and-over",
+          },
+          {
+            code: "QS112EW0007",
+            name: "One family only: Married couple: Total",
+            slug: "one-family-only-married-couple-total",
+          },
+          {
+            code: "QS112EW0008",
+            name: "One family only: Married couple: No children",
+            slug: "one-family-only-married-couple-no-children",
+          },
+          {
+            code: "QS112EW0009",
+            name: "One family only: Married couple: One dependent child",
+            slug: "one-family-only-married-couple-one-dependent-child",
+          },
+          {
+            code: "QS112EW0010",
+            name: "One family only: Married couple: Two or more dependent children",
+            slug: "one-family-only-married-couple-two-or-more-dependent-children",
+          },
+          {
+            code: "QS112EW0011",
+            name: "One family only: Married couple: All children non-dependent",
+            slug: "one-family-only-married-couple-all-children-non-dependent",
+          },
+          {
+            code: "QS112EW0012",
+            name: "One family only: Same-sex civil partnership couple: Total",
+            slug: "one-family-only-same-sex-civil-partnership-couple-total",
+          },
+          {
+            code: "QS112EW0013",
+            name: "One family only: Same-sex civil partnership couple: No children",
+            slug: "one-family-only-same-sex-civil-partnership-couple-no-children",
+          },
+          {
+            code: "QS112EW0014",
+            name: "One family only: Same-sex civil partnership couple: One dependent child",
+            slug: "one-family-only-same-sex-civil-partnership-couple-one-dependent-child",
+          },
+          {
+            code: "QS112EW0015",
+            name: "One family only: Same-sex civil partnership couple: Two or more dependent children",
+            slug: "one-family-only-same-sex-civil-partnership-couple-two-or-more-dependent-children",
+          },
+          {
+            code: "QS112EW0016",
+            name: "One family only: Same-sex civil partnership couple: All children non-dependent",
+            slug: "one-family-only-same-sex-civil-partnership-couple-all-children-non-dependent",
+          },
+          {
+            code: "QS112EW0017",
+            name: "One family only: Cohabiting couple: Total",
+            slug: "one-family-only-cohabiting-couple-total",
+          },
+          {
+            code: "QS112EW0018",
+            name: "One family only: Cohabiting couple: No children",
+            slug: "one-family-only-cohabiting-couple-no-children",
+          },
+          {
+            code: "QS112EW0019",
+            name: "One family only: Cohabiting couple: One dependent child",
+            slug: "one-family-only-cohabiting-couple-one-dependent-child",
+          },
+          {
+            code: "QS112EW0020",
+            name: "One family only: Cohabiting couple: Two or more dependent children",
+            slug: "one-family-only-cohabiting-couple-two-or-more-dependent-children",
+          },
+          {
+            code: "QS112EW0021",
+            name: "One family only: Cohabiting couple: All children non-dependent",
+            slug: "one-family-only-cohabiting-couple-all-children-non-dependent",
+          },
+          {
+            code: "QS112EW0022",
+            name: "One family only: Lone parent: Total",
+            slug: "one-family-only-lone-parent-total",
+          },
+          {
+            code: "QS112EW0023",
+            name: "One family only: Lone parent: One dependent child",
+            slug: "one-family-only-lone-parent-one-dependent-child",
+          },
+          {
+            code: "QS112EW0024",
+            name: "One family only: Lone parent: Two or more dependent children",
+            slug: "one-family-only-lone-parent-two-or-more-dependent-children",
+          },
+          {
+            code: "QS112EW0025",
+            name: "One family only: Lone parent: All children non-dependent",
+            slug: "one-family-only-lone-parent-all-children-non-dependent",
+          },
+          {
+            code: "QS112EW0026",
+            name: "Other household types: Total",
+            slug: "other-household-types-total",
+          },
+          {
+            code: "QS112EW0027",
+            name: "Other household types: With one dependent child",
+            slug: "other-household-types-with-one-dependent-child",
+          },
+          {
+            code: "QS112EW0028",
+            name: "Other household types: With two or more dependent children",
+            slug: "other-household-types-with-two-or-more-dependent-children",
+          },
+          {
+            code: "QS112EW0029",
+            name: "Other household types: All full-time students",
+            slug: "other-household-types-all-full-time-students",
+          },
+          {
+            code: "QS112EW0030",
+            name: "Other household types: All aged 65 and over",
+            slug: "other-household-types-all-aged-65-and-over",
+          },
+          {
+            code: "QS112EW0031",
+            name: "Other household types: Other",
+            slug: "other-household-types-other",
+          },
+        ],
+        code: "QS112EW",
+        name: "Families living in the same home",
+        slug: "families-living-in-the-same-home",
+        desc: "Types of families living in the same home.",
+        total: {
+          code: "QS112EW0001",
+          name: "All categories: Household composition",
+          slug: "all-categories-household-composition",
+        },
+        units: "Households",
+      },
+      {
+        categories: [
+          {
+            code: "QS101EW0002",
+            name: "Lives in a household",
+            slug: "lives-in-a-household",
+          },
+          {
+            code: "QS101EW0003",
+            name: "Lives in a communal establishment",
+            slug: "lives-in-a-communal-establishment",
+          },
+          {
+            code: "QS101EW0004",
+            name: "Communal establishments with persons sleeping rough identified",
+            slug: "communal-establishments-with-persons-sleeping-rough-identified",
+          },
+        ],
+        code: "QS101EW",
+        name: "Residence type",
+        slug: "residence-type",
+        desc: "Families and other groups living in the same home or communal establishment.",
+        total: {
+          code: "QS101EW0001",
+          name: "All categories: Residence type",
+          slug: "all-categories-residence-type",
+        },
+        units: "People (usual residents)",
+      },
+      {
+        categories: [
+          {
+            code: "KS206EW0002",
+            name: "All people aged 16 and over in household have English as a main language (English or Welsh in Wales)",
+            slug: "all-people-aged-16-and-over-in-household-have-english-as-a-main-language-english-or-welsh-in-wales",
+          },
+          {
+            code: "KS206EW0003",
+            name: "At least one but not all people aged 16 and over in household have English as a main language (English or Welsh in Wales)",
+            slug: "at-least-one-but-not-all-people-aged-16-and-over-in-household-have-english-as-a-main-language-english-or-welsh-in-wales",
+          },
+          {
+            code: "KS206EW0004",
+            name: "No people aged 16 and over in household but at least one person aged 3 to 15 has English as a main language (English or Welsh in Wales)",
+            slug: "no-people-aged-16-and-over-in-household-but-at-least-one-person-aged-3-to-15-has-english-as-a-main-language-english-or-welsh-in-wales",
+          },
+          {
+            code: "KS206EW0005",
+            name: "No people in household have English as a main language (English or Welsh in Wales)",
+            slug: "no-people-in-household-have-english-as-a-main-language-english-or-welsh-in-wales",
+          },
+          {
+            code: "KS206EW0006",
+            name: "All people aged 16 and over in household have English as a main language (English or Welsh in Wales)",
+            slug: "all-people-aged-16-and-over-in-household-have-english-as-a-main-language-english-or-welsh-in-wales",
+          },
+          {
+            code: "KS206EW0007",
+            name: "At least one but not all people aged 16 and over in household have English as a main language (English or Welsh in Wales)",
+            slug: "at-least-one-but-not-all-people-aged-16-and-over-in-household-have-english-as-a-main-language-english-or-welsh-in-wales",
+          },
+          {
+            code: "KS206EW0008",
+            name: "No people aged 16 and over in household but at least one person aged 3 to 15 has English as a main language (English or Welsh in Wales)",
+            slug: "no-people-aged-16-and-over-in-household-but-at-least-one-person-aged-3-to-15-has-english-as-a-main-language-english-or-welsh-in-wales",
+          },
+          {
+            code: "KS206EW0009",
+            name: "No people in household have English as a main language (English or Welsh in Wales)",
+            slug: "no-people-in-household-have-english-as-a-main-language-english-or-welsh-in-wales",
+          },
+        ],
+        code: "KS206EW",
+        name: "Language",
+        slug: "language",
+        desc: "English is the main household language.",
+        total: {
+          code: "KS206EW0001",
+          name: "All categories: English as a household language",
+          slug: "all-categories-english-as-a-household-language",
+        },
+        units: "Households",
+      },
+    ],
   },
   {
-      "code": "Work",
-      "name": "Work",
-      "slug": "work",
-      "desc": "Residents employment status.",
-      "tables": [
+    code: "Work",
+    name: "Work",
+    slug: "work",
+    desc: "Residents employment status.",
+    tables: [
+      {
+        categories: [
           {
-              "categories": [
-                  {
-                      "code": "QS601EW0002",
-                      "name": "Economically active: Total",
-                      "slug": "economically-active-total"
-                  },
-                  {
-                      "code": "QS601EW0003",
-                      "name": "Economically active: Employee: Part-time",
-                      "slug": "economically-active-employee-part-time"
-                  },
-                  {
-                      "code": "QS601EW0004",
-                      "name": "Economically active: Employee: Full-time",
-                      "slug": "economically-active-employee-full-time"
-                  },
-                  {
-                      "code": "QS601EW0005",
-                      "name": "Economically active: Self-employed with employees: Part-time",
-                      "slug": "economically-active-self-employed-with-employees-part-time"
-                  },
-                  {
-                      "code": "QS601EW0006",
-                      "name": "Economically active: Self-employed with employees: Full-time",
-                      "slug": "economically-active-self-employed-with-employees-full-time"
-                  },
-                  {
-                      "code": "QS601EW0007",
-                      "name": "Economically active: Self-employed without employees: Part-time",
-                      "slug": "economically-active-self-employed-without-employees-part-time"
-                  },
-                  {
-                      "code": "QS601EW0008",
-                      "name": "Economically active: Self-employed without employees: Full-time",
-                      "slug": "economically-active-self-employed-without-employees-full-time"
-                  },
-                  {
-                      "code": "QS601EW0009",
-                      "name": "Economically active: Unemployed",
-                      "slug": "economically-active-unemployed"
-                  },
-                  {
-                      "code": "QS601EW0010",
-                      "name": "Economically active: Full-time student",
-                      "slug": "economically-active-full-time-student"
-                  },
-                  {
-                      "code": "QS601EW0011",
-                      "name": "Economically inactive: Total",
-                      "slug": "economically-inactive-total"
-                  },
-                  {
-                      "code": "QS601EW0012",
-                      "name": "Economically inactive: Retired",
-                      "slug": "economically-inactive-retired"
-                  },
-                  {
-                      "code": "QS601EW0013",
-                      "name": "Economically inactive: Student (including full-time students)",
-                      "slug": "economically-inactive-student-including-full-time-students"
-                  },
-                  {
-                      "code": "QS601EW0014",
-                      "name": "Economically inactive: Looking after home or family",
-                      "slug": "economically-inactive-looking-after-home-or-family"
-                  },
-                  {
-                      "code": "QS601EW0015",
-                      "name": "Economically inactive: Long-term sick or disabled",
-                      "slug": "economically-inactive-long-term-sick-or-disabled"
-                  },
-                  {
-                      "code": "QS601EW0016",
-                      "name": "Economically inactive: Other",
-                      "slug": "economically-inactive-other"
-                  }
-              ],
-              "code": "QS601EW",
-              "name": "Economic activity",
-              "slug": "economic-activity",
-              "desc": "People who are in work, starting work, looking for or do not work.",
-              "total": {
-                  "code": "QS601EW0001",
-                  "name": "All categories: Economic activity",
-                  "slug": "all-categories-economic-activity"
-              },
-              "units": "People (usual residents)"
+            code: "QS601EW0002",
+            name: "Economically active: Total",
+            slug: "economically-active-total",
           },
           {
-              "categories": [
-                  {
-                      "code": "QS604EW0002",
-                      "name": "Part-time: Total",
-                      "slug": "part-time-total"
-                  },
-                  {
-                      "code": "QS604EW0003",
-                      "name": "Part-time: 15 hours or less worked",
-                      "slug": "part-time-15-hours-or-less-worked"
-                  },
-                  {
-                      "code": "QS604EW0004",
-                      "name": "Part-time: 16 to 30 hours worked",
-                      "slug": "part-time-16-to-30-hours-worked"
-                  },
-                  {
-                      "code": "QS604EW0005",
-                      "name": "Full-time: Total",
-                      "slug": "full-time-total"
-                  },
-                  {
-                      "code": "QS604EW0006",
-                      "name": "Full-time: 31 to 48 hours worked",
-                      "slug": "full-time-31-to-48-hours-worked"
-                  },
-                  {
-                      "code": "QS604EW0007",
-                      "name": "Full-time: 49 or more hours worked",
-                      "slug": "full-time-49-or-more-hours-worked"
-                  }
-              ],
-              "code": "QS604EW",
-              "name": "Working hours",
-              "slug": "working-hours",
-              "desc": "Hours people work per week.",
-              "total": {
-                  "code": "QS604EW0001",
-                  "name": "All categories: Hours worked",
-                  "slug": "all-categories-hours-worked"
-              },
-              "units": "People (usual residents who have a job or their last job)"
+            code: "QS601EW0003",
+            name: "Economically active: Employee: Part-time",
+            slug: "economically-active-employee-part-time",
           },
           {
-              "categories": [
-                  {
-                      "code": "QS605EW0002",
-                      "name": "A Agriculture, forestry and fishing",
-                      "slug": "a-agriculture-forestry-and-fishing"
-                  },
-                  {
-                      "code": "QS605EW0003",
-                      "name": "B Mining and quarrying",
-                      "slug": "b-mining-and-quarrying"
-                  },
-                  {
-                      "code": "QS605EW0004",
-                      "name": "C Manufacturing",
-                      "slug": "c-manufacturing"
-                  },
-                  {
-                      "code": "QS605EW0005",
-                      "name": "C10-12 Manufacturing: Food, beverages and tobacco",
-                      "slug": "c10-12-manufacturing-food-beverages-and-tobacco"
-                  },
-                  {
-                      "code": "QS605EW0006",
-                      "name": "C13-15 Manufacturing: Textiles, wearing apparel and leather and related products",
-                      "slug": "c13-15-manufacturing-textiles-wearing-apparel-and-leather-and-related-products"
-                  },
-                  {
-                      "code": "QS605EW0007",
-                      "name": "C16,17 Manufacturing: Wood, paper and paper products",
-                      "slug": "c16-17-manufacturing-wood-paper-and-paper-products"
-                  },
-                  {
-                      "code": "QS605EW0008",
-                      "name": "C19-22 Manufacturing: Chemicals, chemical products, rubber and plastic",
-                      "slug": "c19-22-manufacturing-chemicals-chemical-products-rubber-and-plastic"
-                  },
-                  {
-                      "code": "QS605EW0009",
-                      "name": "C23-25 Manufacturing: Low tech",
-                      "slug": "c23-25-manufacturing-low-tech"
-                  },
-                  {
-                      "code": "QS605EW0010",
-                      "name": "C26-30 Manufacturing: High tech",
-                      "slug": "c26-30-manufacturing-high-tech"
-                  },
-                  {
-                      "code": "QS605EW0011",
-                      "name": "C18, 31, 32 Manufacturing: Other",
-                      "slug": "c18-31-32-manufacturing-other"
-                  },
-                  {
-                      "code": "QS605EW0012",
-                      "name": "D Electricity, gas, steam and air conditioning supply",
-                      "slug": "d-electricity-gas-steam-and-air-conditioning-supply"
-                  },
-                  {
-                      "code": "QS605EW0013",
-                      "name": "E Water supply, sewerage, waste management and remediation activities",
-                      "slug": "e-water-supply-sewerage-waste-management-and-remediation-activities"
-                  },
-                  {
-                      "code": "QS605EW0014",
-                      "name": "F Construction",
-                      "slug": "f-construction"
-                  },
-                  {
-                      "code": "QS605EW0015",
-                      "name": "G Wholesale and retail trade; repair of motor vehicles and motor cycles",
-                      "slug": "g-wholesale-and-retail-trade-repair-of-motor-vehicles-and-motor-cycles"
-                  },
-                  {
-                      "code": "QS605EW0016",
-                      "name": "H Transport and storage",
-                      "slug": "h-transport-and-storage"
-                  },
-                  {
-                      "code": "QS605EW0017",
-                      "name": "I Accommodation and food service activities",
-                      "slug": "i-accommodation-and-food-service-activities"
-                  },
-                  {
-                      "code": "QS605EW0018",
-                      "name": "J Information and communication",
-                      "slug": "j-information-and-communication"
-                  },
-                  {
-                      "code": "QS605EW0019",
-                      "name": "K Financial and insurance activities",
-                      "slug": "k-financial-and-insurance-activities"
-                  },
-                  {
-                      "code": "QS605EW0020",
-                      "name": "L Real estate activities",
-                      "slug": "l-real-estate-activities"
-                  },
-                  {
-                      "code": "QS605EW0021",
-                      "name": "M Professional, scientific and technical activities",
-                      "slug": "m-professional-scientific-and-technical-activities"
-                  },
-                  {
-                      "code": "QS605EW0022",
-                      "name": "N Administrative and support service activities",
-                      "slug": "n-administrative-and-support-service-activities"
-                  },
-                  {
-                      "code": "QS605EW0023",
-                      "name": "O Public administration and defence; compulsory social security",
-                      "slug": "o-public-administration-and-defence-compulsory-social-security"
-                  },
-                  {
-                      "code": "QS605EW0024",
-                      "name": "P Education",
-                      "slug": "p-education"
-                  },
-                  {
-                      "code": "QS605EW0025",
-                      "name": "Q Human health and social work activities",
-                      "slug": "q-human-health-and-social-work-activities"
-                  },
-                  {
-                      "code": "QS605EW0026",
-                      "name": "R,S Arts, entertainment and recreation; other service activities",
-                      "slug": "r-s-arts-entertainment-and-recreation-other-service-activities"
-                  },
-                  {
-                      "code": "QS605EW0027",
-                      "name": "T Activities of households as employers; undifferentiated goods - and services - producing activities of households for own use",
-                      "slug": "t-activities-of-households-as-employers-undifferentiated-goods-and-services-producing-activities-of-households-for-own-use"
-                  },
-                  {
-                      "code": "QS605EW0028",
-                      "name": "U Activities of extraterritorial organisations and bodies",
-                      "slug": "u-activities-of-extraterritorial-organisations-and-bodies"
-                  }
-              ],
-              "code": "QS605EW",
-              "name": "Sector",
-              "slug": "sector",
-              "desc": "Types of sectors people who have a job or their last job worked in.",
-              "total": {
-                  "code": "QS605EW0001",
-                  "name": "All categories: Industry",
-                  "slug": "all-categories-industry"
-              },
-              "units": "People (usual residents)"
+            code: "QS601EW0004",
+            name: "Economically active: Employee: Full-time",
+            slug: "economically-active-employee-full-time",
           },
           {
-              "categories": [
-                  {
-                      "code": "QS606EW0002",
-                      "name": "Managers, directors and senior officials",
-                      "slug": "managers-directors-and-senior-officials"
-                  },
-                  {
-                      "code": "QS606EW0003",
-                      "name": "Managers, directors and senior officials;     Corporate managers and directors",
-                      "slug": "managers-directors-and-senior-officials-corporate-managers-and-directors"
-                  },
-                  {
-                      "code": "QS606EW0004",
-                      "name": "Managers, directors and senior officials;     Corporate managers and directors;         Chief Executives and Senior Officials",
-                      "slug": "managers-directors-and-senior-officials-corporate-managers-and-directors-chief-executives-and-senior-officials"
-                  },
-                  {
-                      "code": "QS606EW0005",
-                      "name": "Managers, directors and senior officials;     Corporate managers and directors;         Production Managers and Directors",
-                      "slug": "managers-directors-and-senior-officials-corporate-managers-and-directors-production-managers-and-directors"
-                  },
-                  {
-                      "code": "QS606EW0006",
-                      "name": "Managers, directors and senior officials;     Corporate managers and directors;         Functional Managers and Directors",
-                      "slug": "managers-directors-and-senior-officials-corporate-managers-and-directors-functional-managers-and-directors"
-                  },
-                  {
-                      "code": "QS606EW0007",
-                      "name": "Managers, directors and senior officials;     Corporate managers and directors;         Financial Institution Managers and Directors",
-                      "slug": "managers-directors-and-senior-officials-corporate-managers-and-directors-financial-institution-managers-and-directors"
-                  },
-                  {
-                      "code": "QS606EW0008",
-                      "name": "Managers, directors and senior officials;     Corporate managers and directors;         Managers and Directors in Transport and Logistics",
-                      "slug": "managers-directors-and-senior-officials-corporate-managers-and-directors-managers-and-directors-in-transport-and-logistics"
-                  },
-                  {
-                      "code": "QS606EW0009",
-                      "name": "Managers, directors and senior officials;     Corporate managers and directors;         Senior Officers in Protective Services",
-                      "slug": "managers-directors-and-senior-officials-corporate-managers-and-directors-senior-officers-in-protective-services"
-                  },
-                  {
-                      "code": "QS606EW0010",
-                      "name": "Managers, directors and senior officials;     Corporate managers and directors;         Health and Social Services Managers and Directors",
-                      "slug": "managers-directors-and-senior-officials-corporate-managers-and-directors-health-and-social-services-managers-and-directors"
-                  },
-                  {
-                      "code": "QS606EW0011",
-                      "name": "Managers, directors and senior officials;     Corporate managers and directors;         Managers and Directors in Retail and Wholesale",
-                      "slug": "managers-directors-and-senior-officials-corporate-managers-and-directors-managers-and-directors-in-retail-and-wholesale"
-                  },
-                  {
-                      "code": "QS606EW0012",
-                      "name": "Managers, directors and senior officials;     Other managers and proprietors",
-                      "slug": "managers-directors-and-senior-officials-other-managers-and-proprietors"
-                  },
-                  {
-                      "code": "QS606EW0013",
-                      "name": "Managers, directors and senior officials;     Other managers and proprietors;         Managers and Proprietors in Agriculture Related Services",
-                      "slug": "managers-directors-and-senior-officials-other-managers-and-proprietors-managers-and-proprietors-in-agriculture-related-services"
-                  },
-                  {
-                      "code": "QS606EW0014",
-                      "name": "Managers, directors and senior officials;     Other managers and proprietors;         Managers and Proprietors in Hospitality and Leisure Services",
-                      "slug": "managers-directors-and-senior-officials-other-managers-and-proprietors-managers-and-proprietors-in-hospitality-and-leisure-services"
-                  },
-                  {
-                      "code": "QS606EW0015",
-                      "name": "Managers, directors and senior officials;     Other managers and proprietors;         Managers and Proprietors in Health and Care Services",
-                      "slug": "managers-directors-and-senior-officials-other-managers-and-proprietors-managers-and-proprietors-in-health-and-care-services"
-                  },
-                  {
-                      "code": "QS606EW0016",
-                      "name": "Managers, directors and senior officials;     Other managers and proprietors;         Managers and Proprietors in Other Services",
-                      "slug": "managers-directors-and-senior-officials-other-managers-and-proprietors-managers-and-proprietors-in-other-services"
-                  },
-                  {
-                      "code": "QS606EW0017",
-                      "name": "Professional occupations",
-                      "slug": "professional-occupations"
-                  },
-                  {
-                      "code": "QS606EW0018",
-                      "name": "Professional occupations;     Science, research, engineering and technology professionals",
-                      "slug": "professional-occupations-science-research-engineering-and-technology-professionals"
-                  },
-                  {
-                      "code": "QS606EW0019",
-                      "name": "Professional occupations;     Science, research, engineering and technology professionals;         Natural and Social Science Professionals",
-                      "slug": "professional-occupations-science-research-engineering-and-technology-professionals-natural-and-social-science-professionals"
-                  },
-                  {
-                      "code": "QS606EW0020",
-                      "name": "Professional occupations;     Science, research, engineering and technology professionals;         Engineering Professionals",
-                      "slug": "professional-occupations-science-research-engineering-and-technology-professionals-engineering-professionals"
-                  },
-                  {
-                      "code": "QS606EW0021",
-                      "name": "Professional occupations;     Science, research, engineering and technology professionals;         Information Technology and Telecommunications Professionals",
-                      "slug": "professional-occupations-science-research-engineering-and-technology-professionals-information-technology-and-telecommunications-professionals"
-                  },
-                  {
-                      "code": "QS606EW0022",
-                      "name": "Professional occupations;     Science, research, engineering and technology professionals;         Conservation and Environment Professionals",
-                      "slug": "professional-occupations-science-research-engineering-and-technology-professionals-conservation-and-environment-professionals"
-                  },
-                  {
-                      "code": "QS606EW0023",
-                      "name": "Professional occupations;     Science, research, engineering and technology professionals;         Research and Development Managers ",
-                      "slug": "professional-occupations-science-research-engineering-and-technology-professionals-research-and-development-managers"
-                  },
-                  {
-                      "code": "QS606EW0024",
-                      "name": "Professional occupations;     Health professionals",
-                      "slug": "professional-occupations-health-professionals"
-                  },
-                  {
-                      "code": "QS606EW0025",
-                      "name": "Professional occupations;     Health professionals;         Health Professionals",
-                      "slug": "professional-occupations-health-professionals-health-professionals"
-                  },
-                  {
-                      "code": "QS606EW0026",
-                      "name": "Professional occupations;     Health professionals;         Therapy Professionals",
-                      "slug": "professional-occupations-health-professionals-therapy-professionals"
-                  },
-                  {
-                      "code": "QS606EW0027",
-                      "name": "Professional occupations;     Health professionals;         Nursing and Midwifery Professionals",
-                      "slug": "professional-occupations-health-professionals-nursing-and-midwifery-professionals"
-                  },
-                  {
-                      "code": "QS606EW0028",
-                      "name": "Professional occupations;     Teaching and educational professionals",
-                      "slug": "professional-occupations-teaching-and-educational-professionals"
-                  },
-                  {
-                      "code": "QS606EW0029",
-                      "name": "Professional occupations;     Teaching and educational professionals;         Teaching and Educational Professionals",
-                      "slug": "professional-occupations-teaching-and-educational-professionals-teaching-and-educational-professionals"
-                  },
-                  {
-                      "code": "QS606EW0030",
-                      "name": "Professional occupations;     Business, media and public service professionals",
-                      "slug": "professional-occupations-business-media-and-public-service-professionals"
-                  },
-                  {
-                      "code": "QS606EW0031",
-                      "name": "Professional occupations;     Business, media and public service professionals;         Legal Professionals",
-                      "slug": "professional-occupations-business-media-and-public-service-professionals-legal-professionals"
-                  },
-                  {
-                      "code": "QS606EW0032",
-                      "name": "Professional occupations;     Business, media and public service professionals;         Business, Research and Administrative Professionals",
-                      "slug": "professional-occupations-business-media-and-public-service-professionals-business-research-and-administrative-professionals"
-                  },
-                  {
-                      "code": "QS606EW0033",
-                      "name": "Professional occupations;     Business, media and public service professionals;         Architects, Town Planners and Surveyors",
-                      "slug": "professional-occupations-business-media-and-public-service-professionals-architects-town-planners-and-surveyors"
-                  },
-                  {
-                      "code": "QS606EW0034",
-                      "name": "Professional occupations;     Business, media and public service professionals;         Welfare Professionals",
-                      "slug": "professional-occupations-business-media-and-public-service-professionals-welfare-professionals"
-                  },
-                  {
-                      "code": "QS606EW0035",
-                      "name": "Professional occupations;     Business, media and public service professionals;         Librarians and Related Professionals",
-                      "slug": "professional-occupations-business-media-and-public-service-professionals-librarians-and-related-professionals"
-                  },
-                  {
-                      "code": "QS606EW0036",
-                      "name": "Professional occupations;     Business, media and public service professionals;         Quality and Regulatory Professionals",
-                      "slug": "professional-occupations-business-media-and-public-service-professionals-quality-and-regulatory-professionals"
-                  },
-                  {
-                      "code": "QS606EW0037",
-                      "name": "Professional occupations;     Business, media and public service professionals;         Media Professionals",
-                      "slug": "professional-occupations-business-media-and-public-service-professionals-media-professionals"
-                  },
-                  {
-                      "code": "QS606EW0038",
-                      "name": "Associate professional and technical occupations",
-                      "slug": "associate-professional-and-technical-occupations"
-                  },
-                  {
-                      "code": "QS606EW0039",
-                      "name": "Associate professional and technical occupations;     Science, engineering and technology associate professionals",
-                      "slug": "associate-professional-and-technical-occupations-science-engineering-and-technology-associate-professionals"
-                  },
-                  {
-                      "code": "QS606EW0040",
-                      "name": "Associate professional and technical occupations;     Science, engineering and technology associate professionals;         Science, Engineering and Production Technicians",
-                      "slug": "associate-professional-and-technical-occupations-science-engineering-and-technology-associate-professionals-science-engineering-and-production-technicians"
-                  },
-                  {
-                      "code": "QS606EW0041",
-                      "name": "Associate professional and technical occupations;     Science, engineering and technology associate professionals;         Draughtspersons and Related Architectural Technicians",
-                      "slug": "associate-professional-and-technical-occupations-science-engineering-and-technology-associate-professionals-draughtspersons-and-related-architectural-technicians"
-                  },
-                  {
-                      "code": "QS606EW0042",
-                      "name": "Associate professional and technical occupations;     Science, engineering and technology associate professionals;         Information Technology Technicians",
-                      "slug": "associate-professional-and-technical-occupations-science-engineering-and-technology-associate-professionals-information-technology-technicians"
-                  },
-                  {
-                      "code": "QS606EW0043",
-                      "name": "Associate professional and technical occupations;     Health and social care associate professionals",
-                      "slug": "associate-professional-and-technical-occupations-health-and-social-care-associate-professionals"
-                  },
-                  {
-                      "code": "QS606EW0044",
-                      "name": "Associate professional and technical occupations;     Health and social care associate professionals;         Health Associate Professionals",
-                      "slug": "associate-professional-and-technical-occupations-health-and-social-care-associate-professionals-health-associate-professionals"
-                  },
-                  {
-                      "code": "QS606EW0045",
-                      "name": "Associate professional and technical occupations;     Health and social care associate professionals;         Welfare and Housing Associate Professionals",
-                      "slug": "associate-professional-and-technical-occupations-health-and-social-care-associate-professionals-welfare-and-housing-associate-professionals"
-                  },
-                  {
-                      "code": "QS606EW0046",
-                      "name": "Associate professional and technical occupations;     Protective service occupations",
-                      "slug": "associate-professional-and-technical-occupations-protective-service-occupations"
-                  },
-                  {
-                      "code": "QS606EW0047",
-                      "name": "Associate professional and technical occupations;     Protective service occupations;         Protective Service Occupations",
-                      "slug": "associate-professional-and-technical-occupations-protective-service-occupations-protective-service-occupations"
-                  },
-                  {
-                      "code": "QS606EW0048",
-                      "name": "Associate professional and technical occupations;     Culture, media and sports occupations",
-                      "slug": "associate-professional-and-technical-occupations-culture-media-and-sports-occupations"
-                  },
-                  {
-                      "code": "QS606EW0049",
-                      "name": "Associate professional and technical occupations;     Culture, media and sports occupations;         Artistic, Literary and Media Occupations",
-                      "slug": "associate-professional-and-technical-occupations-culture-media-and-sports-occupations-artistic-literary-and-media-occupations"
-                  },
-                  {
-                      "code": "QS606EW0050",
-                      "name": "Associate professional and technical occupations;     Culture, media and sports occupations;         Design Occupations",
-                      "slug": "associate-professional-and-technical-occupations-culture-media-and-sports-occupations-design-occupations"
-                  },
-                  {
-                      "code": "QS606EW0051",
-                      "name": "Associate professional and technical occupations;     Culture, media and sports occupations;         Sports and Fitness Occupations",
-                      "slug": "associate-professional-and-technical-occupations-culture-media-and-sports-occupations-sports-and-fitness-occupations"
-                  },
-                  {
-                      "code": "QS606EW0052",
-                      "name": "Associate professional and technical occupations;     Business and public service associate professionals",
-                      "slug": "associate-professional-and-technical-occupations-business-and-public-service-associate-professionals"
-                  },
-                  {
-                      "code": "QS606EW0053",
-                      "name": "Associate professional and technical occupations;     Business and public service associate professionals;         Transport Associate Professionals",
-                      "slug": "associate-professional-and-technical-occupations-business-and-public-service-associate-professionals-transport-associate-professionals"
-                  },
-                  {
-                      "code": "QS606EW0054",
-                      "name": "Associate professional and technical occupations;     Business and public service associate professionals;         Legal Associate Professionals",
-                      "slug": "associate-professional-and-technical-occupations-business-and-public-service-associate-professionals-legal-associate-professionals"
-                  },
-                  {
-                      "code": "QS606EW0055",
-                      "name": "Associate professional and technical occupations;     Business and public service associate professionals;         Business, Finance and Related Associate Professionals",
-                      "slug": "associate-professional-and-technical-occupations-business-and-public-service-associate-professionals-business-finance-and-related-associate-professionals"
-                  },
-                  {
-                      "code": "QS606EW0056",
-                      "name": "Associate professional and technical occupations;     Business and public service associate professionals;         Sales, Marketing and Related Associate Professionals",
-                      "slug": "associate-professional-and-technical-occupations-business-and-public-service-associate-professionals-sales-marketing-and-related-associate-professionals"
-                  },
-                  {
-                      "code": "QS606EW0057",
-                      "name": "Associate professional and technical occupations;     Business and public service associate professionals;         Conservation and Environmental associate professionals",
-                      "slug": "associate-professional-and-technical-occupations-business-and-public-service-associate-professionals-conservation-and-environmental-associate-professionals"
-                  },
-                  {
-                      "code": "QS606EW0058",
-                      "name": "Associate professional and technical occupations;     Business and public service associate professionals;         Public Services and Other Associate Professionals",
-                      "slug": "associate-professional-and-technical-occupations-business-and-public-service-associate-professionals-public-services-and-other-associate-professionals"
-                  },
-                  {
-                      "code": "QS606EW0059",
-                      "name": "Administrative and secretarial occupations",
-                      "slug": "administrative-and-secretarial-occupations"
-                  },
-                  {
-                      "code": "QS606EW0060",
-                      "name": "Administrative and secretarial occupations;     Administrative occupations",
-                      "slug": "administrative-and-secretarial-occupations-administrative-occupations"
-                  },
-                  {
-                      "code": "QS606EW0061",
-                      "name": "Administrative and secretarial occupations;     Administrative occupations;         Administrative Occupations: Government and Related Organisations",
-                      "slug": "administrative-and-secretarial-occupations-administrative-occupations-administrative-occupations-government-and-related-organisations"
-                  },
-                  {
-                      "code": "QS606EW0062",
-                      "name": "Administrative and secretarial occupations;     Administrative occupations;         Administrative Occupations: Finance",
-                      "slug": "administrative-and-secretarial-occupations-administrative-occupations-administrative-occupations-finance"
-                  },
-                  {
-                      "code": "QS606EW0063",
-                      "name": "Administrative and secretarial occupations;     Administrative occupations;         Administrative Occupations: Records",
-                      "slug": "administrative-and-secretarial-occupations-administrative-occupations-administrative-occupations-records"
-                  },
-                  {
-                      "code": "QS606EW0064",
-                      "name": "Administrative and secretarial occupations;     Administrative occupations;         Other Administrative Occupations",
-                      "slug": "administrative-and-secretarial-occupations-administrative-occupations-other-administrative-occupations"
-                  },
-                  {
-                      "code": "QS606EW0065",
-                      "name": "Administrative and secretarial occupations;     Administrative occupations;         Administrative Occupations: Office Managers and Supervisors",
-                      "slug": "administrative-and-secretarial-occupations-administrative-occupations-administrative-occupations-office-managers-and-supervisors"
-                  },
-                  {
-                      "code": "QS606EW0066",
-                      "name": "Administrative and secretarial occupations;     Secretarial and related occupations",
-                      "slug": "administrative-and-secretarial-occupations-secretarial-and-related-occupations"
-                  },
-                  {
-                      "code": "QS606EW0067",
-                      "name": "Administrative and secretarial occupations;     Secretarial and related occupations;         Secretarial and Related Occupations",
-                      "slug": "administrative-and-secretarial-occupations-secretarial-and-related-occupations-secretarial-and-related-occupations"
-                  },
-                  {
-                      "code": "QS606EW0068",
-                      "name": "Skilled trades occupations",
-                      "slug": "skilled-trades-occupations"
-                  },
-                  {
-                      "code": "QS606EW0069",
-                      "name": "Skilled trades occupations;     Skilled agricultural and related trades",
-                      "slug": "skilled-trades-occupations-skilled-agricultural-and-related-trades"
-                  },
-                  {
-                      "code": "QS606EW0070",
-                      "name": "Skilled trades occupations;     Skilled agricultural and related trades;         Agricultural and Related Trades",
-                      "slug": "skilled-trades-occupations-skilled-agricultural-and-related-trades-agricultural-and-related-trades"
-                  },
-                  {
-                      "code": "QS606EW0071",
-                      "name": "Skilled trades occupations;     Skilled metal, electrical and electronic trades",
-                      "slug": "skilled-trades-occupations-skilled-metal-electrical-and-electronic-trades"
-                  },
-                  {
-                      "code": "QS606EW0072",
-                      "name": "Skilled trades occupations;     Skilled metal, electrical and electronic trades;         Metal Forming, Welding and Related Trades",
-                      "slug": "skilled-trades-occupations-skilled-metal-electrical-and-electronic-trades-metal-forming-welding-and-related-trades"
-                  },
-                  {
-                      "code": "QS606EW0073",
-                      "name": "Skilled trades occupations;     Skilled metal, electrical and electronic trades;         Metal Machining, Fitting and Instrument Making Trades",
-                      "slug": "skilled-trades-occupations-skilled-metal-electrical-and-electronic-trades-metal-machining-fitting-and-instrument-making-trades"
-                  },
-                  {
-                      "code": "QS606EW0074",
-                      "name": "Skilled trades occupations;     Skilled metal, electrical and electronic trades;         Vehicle Trades",
-                      "slug": "skilled-trades-occupations-skilled-metal-electrical-and-electronic-trades-vehicle-trades"
-                  },
-                  {
-                      "code": "QS606EW0075",
-                      "name": "Skilled trades occupations;     Skilled metal, electrical and electronic trades;         Electrical and Electronic Trades",
-                      "slug": "skilled-trades-occupations-skilled-metal-electrical-and-electronic-trades-electrical-and-electronic-trades"
-                  },
-                  {
-                      "code": "QS606EW0076",
-                      "name": "Skilled trades occupations;     Skilled metal, electrical and electronic trades;         Skilled Metal, Electrical and Electronic Trades Supervisors",
-                      "slug": "skilled-trades-occupations-skilled-metal-electrical-and-electronic-trades-skilled-metal-electrical-and-electronic-trades-supervisors"
-                  },
-                  {
-                      "code": "QS606EW0077",
-                      "name": "Skilled trades occupations;     Skilled construction and building trades",
-                      "slug": "skilled-trades-occupations-skilled-construction-and-building-trades"
-                  },
-                  {
-                      "code": "QS606EW0078",
-                      "name": "Skilled trades occupations;     Skilled construction and building trades;         Construction and Building Trades",
-                      "slug": "skilled-trades-occupations-skilled-construction-and-building-trades-construction-and-building-trades"
-                  },
-                  {
-                      "code": "QS606EW0079",
-                      "name": "Skilled trades occupations;     Skilled construction and building trades;         Building Finishing Trades",
-                      "slug": "skilled-trades-occupations-skilled-construction-and-building-trades-building-finishing-trades"
-                  },
-                  {
-                      "code": "QS606EW0080",
-                      "name": "Skilled trades occupations;     Skilled construction and building trades;         Construction and Building Trades Supervisors",
-                      "slug": "skilled-trades-occupations-skilled-construction-and-building-trades-construction-and-building-trades-supervisors"
-                  },
-                  {
-                      "code": "QS606EW0081",
-                      "name": "Skilled trades occupations;     Textiles, printing and other skilled trades",
-                      "slug": "skilled-trades-occupations-textiles-printing-and-other-skilled-trades"
-                  },
-                  {
-                      "code": "QS606EW0082",
-                      "name": "Skilled trades occupations;     Textiles, printing and other skilled trades;         Textiles and Garments Trades",
-                      "slug": "skilled-trades-occupations-textiles-printing-and-other-skilled-trades-textiles-and-garments-trades"
-                  },
-                  {
-                      "code": "QS606EW0083",
-                      "name": "Skilled trades occupations;     Textiles, printing and other skilled trades;         Printing Trades",
-                      "slug": "skilled-trades-occupations-textiles-printing-and-other-skilled-trades-printing-trades"
-                  },
-                  {
-                      "code": "QS606EW0084",
-                      "name": "Skilled trades occupations;     Textiles, printing and other skilled trades;         Food Preparation and Hospitality Trades",
-                      "slug": "skilled-trades-occupations-textiles-printing-and-other-skilled-trades-food-preparation-and-hospitality-trades"
-                  },
-                  {
-                      "code": "QS606EW0085",
-                      "name": "Skilled trades occupations;     Textiles, printing and other skilled trades;         Other Skilled Trades",
-                      "slug": "skilled-trades-occupations-textiles-printing-and-other-skilled-trades-other-skilled-trades"
-                  },
-                  {
-                      "code": "QS606EW0086",
-                      "name": "Caring, leisure and other service occupations",
-                      "slug": "caring-leisure-and-other-service-occupations"
-                  },
-                  {
-                      "code": "QS606EW0087",
-                      "name": "Caring, leisure and other service occupations;     Caring personal service occupations",
-                      "slug": "caring-leisure-and-other-service-occupations-caring-personal-service-occupations"
-                  },
-                  {
-                      "code": "QS606EW0088",
-                      "name": "Caring, leisure and other service occupations;     Caring personal service occupations;         Childcare and Related Personal Services",
-                      "slug": "caring-leisure-and-other-service-occupations-caring-personal-service-occupations-childcare-and-related-personal-services"
-                  },
-                  {
-                      "code": "QS606EW0089",
-                      "name": "Caring, leisure and other service occupations;     Caring personal service occupations;         Animal Care and Control Services",
-                      "slug": "caring-leisure-and-other-service-occupations-caring-personal-service-occupations-animal-care-and-control-services"
-                  },
-                  {
-                      "code": "QS606EW0090",
-                      "name": "Caring, leisure and other service occupations;     Caring personal service occupations;         Caring Personal Services",
-                      "slug": "caring-leisure-and-other-service-occupations-caring-personal-service-occupations-caring-personal-services"
-                  },
-                  {
-                      "code": "QS606EW0091",
-                      "name": "Caring, leisure and other service occupations;     Leisure, travel and related personal service occupations",
-                      "slug": "caring-leisure-and-other-service-occupations-leisure-travel-and-related-personal-service-occupations"
-                  },
-                  {
-                      "code": "QS606EW0092",
-                      "name": "Caring, leisure and other service occupations;     Leisure, travel and related personal service occupations;         Leisure and Travel Services",
-                      "slug": "caring-leisure-and-other-service-occupations-leisure-travel-and-related-personal-service-occupations-leisure-and-travel-services"
-                  },
-                  {
-                      "code": "QS606EW0093",
-                      "name": "Caring, leisure and other service occupations;     Leisure, travel and related personal service occupations;         Hairdressers and Related Services",
-                      "slug": "caring-leisure-and-other-service-occupations-leisure-travel-and-related-personal-service-occupations-hairdressers-and-related-services"
-                  },
-                  {
-                      "code": "QS606EW0094",
-                      "name": "Caring, leisure and other service occupations;     Leisure, travel and related personal service occupations;         Housekeeping and Related Services",
-                      "slug": "caring-leisure-and-other-service-occupations-leisure-travel-and-related-personal-service-occupations-housekeeping-and-related-services"
-                  },
-                  {
-                      "code": "QS606EW0095",
-                      "name": "Caring, leisure and other service occupations;     Leisure, travel and related personal service occupations;         Cleaning and Housekeeping Managers and Supervisors",
-                      "slug": "caring-leisure-and-other-service-occupations-leisure-travel-and-related-personal-service-occupations-cleaning-and-housekeeping-managers-and-supervisors"
-                  },
-                  {
-                      "code": "QS606EW0096",
-                      "name": "Sales and customer service occupations",
-                      "slug": "sales-and-customer-service-occupations"
-                  },
-                  {
-                      "code": "QS606EW0097",
-                      "name": "Sales and customer service occupations;     Sales occupations",
-                      "slug": "sales-and-customer-service-occupations-sales-occupations"
-                  },
-                  {
-                      "code": "QS606EW0098",
-                      "name": "Sales and customer service occupations;     Sales occupations;         Sales Assistants and Retail Cashiers",
-                      "slug": "sales-and-customer-service-occupations-sales-occupations-sales-assistants-and-retail-cashiers"
-                  },
-                  {
-                      "code": "QS606EW0099",
-                      "name": "Sales and customer service occupations;     Sales occupations;         Sales Related Occupations",
-                      "slug": "sales-and-customer-service-occupations-sales-occupations-sales-related-occupations"
-                  },
-                  {
-                      "code": "QS606EW0100",
-                      "name": "Sales and customer service occupations;     Sales occupations;         Sales Supervisors",
-                      "slug": "sales-and-customer-service-occupations-sales-occupations-sales-supervisors"
-                  },
-                  {
-                      "code": "QS606EW0101",
-                      "name": "Sales and customer service occupations;     Customer service occupations",
-                      "slug": "sales-and-customer-service-occupations-customer-service-occupations"
-                  },
-                  {
-                      "code": "QS606EW0102",
-                      "name": "Sales and customer service occupations;     Customer service occupations;         Customer Service Occupations",
-                      "slug": "sales-and-customer-service-occupations-customer-service-occupations-customer-service-occupations"
-                  },
-                  {
-                      "code": "QS606EW0103",
-                      "name": "Sales and customer service occupations;     Customer service occupations;         Customer Service Managers and Supervisors",
-                      "slug": "sales-and-customer-service-occupations-customer-service-occupations-customer-service-managers-and-supervisors"
-                  },
-                  {
-                      "code": "QS606EW0104",
-                      "name": "Process, plant and machine operatives",
-                      "slug": "process-plant-and-machine-operatives"
-                  },
-                  {
-                      "code": "QS606EW0105",
-                      "name": "Process, plant and machine operatives;     Process, plant and machine operatives",
-                      "slug": "process-plant-and-machine-operatives-process-plant-and-machine-operatives"
-                  },
-                  {
-                      "code": "QS606EW0106",
-                      "name": "Process, plant and machine operatives;     Process, plant and machine operatives;         Process Operatives",
-                      "slug": "process-plant-and-machine-operatives-process-plant-and-machine-operatives-process-operatives"
-                  },
-                  {
-                      "code": "QS606EW0107",
-                      "name": "Process, plant and machine operatives;     Process, plant and machine operatives;         Plant and Machine Operatives",
-                      "slug": "process-plant-and-machine-operatives-process-plant-and-machine-operatives-plant-and-machine-operatives"
-                  },
-                  {
-                      "code": "QS606EW0108",
-                      "name": "Process, plant and machine operatives;     Process, plant and machine operatives;         Assemblers and Routine Operatives",
-                      "slug": "process-plant-and-machine-operatives-process-plant-and-machine-operatives-assemblers-and-routine-operatives"
-                  },
-                  {
-                      "code": "QS606EW0109",
-                      "name": "Process, plant and machine operatives;     Process, plant and machine operatives;         Construction Operatives",
-                      "slug": "process-plant-and-machine-operatives-process-plant-and-machine-operatives-construction-operatives"
-                  },
-                  {
-                      "code": "QS606EW0110",
-                      "name": "Process, plant and machine operatives;     Transport and mobile machine drivers and operatives",
-                      "slug": "process-plant-and-machine-operatives-transport-and-mobile-machine-drivers-and-operatives"
-                  },
-                  {
-                      "code": "QS606EW0111",
-                      "name": "Process, plant and machine operatives;     Transport and mobile machine drivers and operatives;         Road Transport Drivers",
-                      "slug": "process-plant-and-machine-operatives-transport-and-mobile-machine-drivers-and-operatives-road-transport-drivers"
-                  },
-                  {
-                      "code": "QS606EW0112",
-                      "name": "Process, plant and machine operatives;     Transport and mobile machine drivers and operatives;         Mobile Machine Drivers and Operatives",
-                      "slug": "process-plant-and-machine-operatives-transport-and-mobile-machine-drivers-and-operatives-mobile-machine-drivers-and-operatives"
-                  },
-                  {
-                      "code": "QS606EW0113",
-                      "name": "Process, plant and machine operatives;     Transport and mobile machine drivers and operatives;         Other Drivers and Transport Operatives",
-                      "slug": "process-plant-and-machine-operatives-transport-and-mobile-machine-drivers-and-operatives-other-drivers-and-transport-operatives"
-                  },
-                  {
-                      "code": "QS606EW0114",
-                      "name": "Elementary occupations",
-                      "slug": "elementary-occupations"
-                  },
-                  {
-                      "code": "QS606EW0115",
-                      "name": "Elementary occupations;     Elementary trades and related occupations",
-                      "slug": "elementary-occupations-elementary-trades-and-related-occupations"
-                  },
-                  {
-                      "code": "QS606EW0116",
-                      "name": "Elementary occupations;     Elementary trades and related occupations;         Elementary Agricultural Occupations",
-                      "slug": "elementary-occupations-elementary-trades-and-related-occupations-elementary-agricultural-occupations"
-                  },
-                  {
-                      "code": "QS606EW0117",
-                      "name": "Elementary occupations;     Elementary trades and related occupations;         Elementary Construction Occupations",
-                      "slug": "elementary-occupations-elementary-trades-and-related-occupations-elementary-construction-occupations"
-                  },
-                  {
-                      "code": "QS606EW0118",
-                      "name": "Elementary occupations;     Elementary trades and related occupations;         Elementary Process Plant Occupations",
-                      "slug": "elementary-occupations-elementary-trades-and-related-occupations-elementary-process-plant-occupations"
-                  },
-                  {
-                      "code": "QS606EW0119",
-                      "name": "Elementary occupations;     Elementary administration and service occupations",
-                      "slug": "elementary-occupations-elementary-administration-and-service-occupations"
-                  },
-                  {
-                      "code": "QS606EW0120",
-                      "name": "Elementary occupations;     Elementary administration and service occupations;         Elementary Administration Occupations",
-                      "slug": "elementary-occupations-elementary-administration-and-service-occupations-elementary-administration-occupations"
-                  },
-                  {
-                      "code": "QS606EW0121",
-                      "name": "Elementary occupations;     Elementary administration and service occupations;         Elementary Cleaning Occupations",
-                      "slug": "elementary-occupations-elementary-administration-and-service-occupations-elementary-cleaning-occupations"
-                  },
-                  {
-                      "code": "QS606EW0122",
-                      "name": "Elementary occupations;     Elementary administration and service occupations;         Elementary Security Occupations",
-                      "slug": "elementary-occupations-elementary-administration-and-service-occupations-elementary-security-occupations"
-                  },
-                  {
-                      "code": "QS606EW0123",
-                      "name": "Elementary occupations;     Elementary administration and service occupations;         Elementary Sales Occupations",
-                      "slug": "elementary-occupations-elementary-administration-and-service-occupations-elementary-sales-occupations"
-                  },
-                  {
-                      "code": "QS606EW0124",
-                      "name": "Elementary occupations;     Elementary administration and service occupations;         Elementary Storage Occupations",
-                      "slug": "elementary-occupations-elementary-administration-and-service-occupations-elementary-storage-occupations"
-                  },
-                  {
-                      "code": "QS606EW0125",
-                      "name": "Elementary occupations;     Elementary administration and service occupations;         Other Elementary Services Occupations",
-                      "slug": "elementary-occupations-elementary-administration-and-service-occupations-other-elementary-services-occupations"
-                  }
-              ],
-              "code": "QS606EW",
-              "name": "Job",
-              "slug": "job",
-              "desc": "The types of jobs people do",
-              "total": {
-                  "code": "QS606EW0001",
-                  "name": "All categories: Occupation",
-                  "slug": "all-categories-occupation"
-              },
-              "units": "People (usual residents)"
+            code: "QS601EW0005",
+            name: "Economically active: Self-employed with employees: Part-time",
+            slug: "economically-active-self-employed-with-employees-part-time",
           },
           {
-              "categories": [
-                  {
-                      "code": "QS701EW0002",
-                      "name": "Work mainly at or from home",
-                      "slug": "work-mainly-at-or-from-home"
-                  },
-                  {
-                      "code": "QS701EW0003",
-                      "name": "Underground, metro, light rail, tram",
-                      "slug": "underground-metro-light-rail-tram"
-                  },
-                  {
-                      "code": "QS701EW0004",
-                      "name": "Train",
-                      "slug": "train"
-                  },
-                  {
-                      "code": "QS701EW0005",
-                      "name": "Bus, minibus or coach",
-                      "slug": "bus-minibus-or-coach"
-                  },
-                  {
-                      "code": "QS701EW0006",
-                      "name": "Taxi",
-                      "slug": "taxi"
-                  },
-                  {
-                      "code": "QS701EW0007",
-                      "name": "Motorcycle, scooter or moped",
-                      "slug": "motorcycle-scooter-or-moped"
-                  },
-                  {
-                      "code": "QS701EW0008",
-                      "name": "Driving a car or van",
-                      "slug": "driving-a-car-or-van"
-                  },
-                  {
-                      "code": "QS701EW0009",
-                      "name": "Passenger in a car or van",
-                      "slug": "passenger-in-a-car-or-van"
-                  },
-                  {
-                      "code": "QS701EW0010",
-                      "name": "Bicycle",
-                      "slug": "bicycle"
-                  },
-                  {
-                      "code": "QS701EW0011",
-                      "name": "On foot",
-                      "slug": "on-foot"
-                  },
-                  {
-                      "code": "QS701EW0012",
-                      "name": "Other method of travel to work",
-                      "slug": "other-method-of-travel-to-work"
-                  },
-                  {
-                      "code": "QS701EW0013",
-                      "name": "Not in employment",
-                      "slug": "not-in-employment"
-                  }
-              ],
-              "code": "QS701EW",
-              "name": "Travel to work",
-              "slug": "travel-to-work",
-              "desc": "Types of transport people use to travel to work.",
-              "total": {
-                  "code": "QS701EW0001",
-                  "name": "All categories: Method of travel to work",
-                  "slug": "all-categories-method-of-travel-to-work"
-              },
-              "units": "People (usual residents)"
-          }
-      ]
-  }
+            code: "QS601EW0006",
+            name: "Economically active: Self-employed with employees: Full-time",
+            slug: "economically-active-self-employed-with-employees-full-time",
+          },
+          {
+            code: "QS601EW0007",
+            name: "Economically active: Self-employed without employees: Part-time",
+            slug: "economically-active-self-employed-without-employees-part-time",
+          },
+          {
+            code: "QS601EW0008",
+            name: "Economically active: Self-employed without employees: Full-time",
+            slug: "economically-active-self-employed-without-employees-full-time",
+          },
+          {
+            code: "QS601EW0009",
+            name: "Economically active: Unemployed",
+            slug: "economically-active-unemployed",
+          },
+          {
+            code: "QS601EW0010",
+            name: "Economically active: Full-time student",
+            slug: "economically-active-full-time-student",
+          },
+          {
+            code: "QS601EW0011",
+            name: "Economically inactive: Total",
+            slug: "economically-inactive-total",
+          },
+          {
+            code: "QS601EW0012",
+            name: "Economically inactive: Retired",
+            slug: "economically-inactive-retired",
+          },
+          {
+            code: "QS601EW0013",
+            name: "Economically inactive: Student (including full-time students)",
+            slug: "economically-inactive-student-including-full-time-students",
+          },
+          {
+            code: "QS601EW0014",
+            name: "Economically inactive: Looking after home or family",
+            slug: "economically-inactive-looking-after-home-or-family",
+          },
+          {
+            code: "QS601EW0015",
+            name: "Economically inactive: Long-term sick or disabled",
+            slug: "economically-inactive-long-term-sick-or-disabled",
+          },
+          {
+            code: "QS601EW0016",
+            name: "Economically inactive: Other",
+            slug: "economically-inactive-other",
+          },
+        ],
+        code: "QS601EW",
+        name: "Economic activity",
+        slug: "economic-activity",
+        desc: "People who are in work, starting work, looking for or do not work.",
+        total: {
+          code: "QS601EW0001",
+          name: "All categories: Economic activity",
+          slug: "all-categories-economic-activity",
+        },
+        units: "People (usual residents)",
+      },
+      {
+        categories: [
+          {
+            code: "QS604EW0002",
+            name: "Part-time: Total",
+            slug: "part-time-total",
+          },
+          {
+            code: "QS604EW0003",
+            name: "Part-time: 15 hours or less worked",
+            slug: "part-time-15-hours-or-less-worked",
+          },
+          {
+            code: "QS604EW0004",
+            name: "Part-time: 16 to 30 hours worked",
+            slug: "part-time-16-to-30-hours-worked",
+          },
+          {
+            code: "QS604EW0005",
+            name: "Full-time: Total",
+            slug: "full-time-total",
+          },
+          {
+            code: "QS604EW0006",
+            name: "Full-time: 31 to 48 hours worked",
+            slug: "full-time-31-to-48-hours-worked",
+          },
+          {
+            code: "QS604EW0007",
+            name: "Full-time: 49 or more hours worked",
+            slug: "full-time-49-or-more-hours-worked",
+          },
+        ],
+        code: "QS604EW",
+        name: "Working hours",
+        slug: "working-hours",
+        desc: "Hours people work per week.",
+        total: {
+          code: "QS604EW0001",
+          name: "All categories: Hours worked",
+          slug: "all-categories-hours-worked",
+        },
+        units: "People (usual residents who have a job or their last job)",
+      },
+      {
+        categories: [
+          {
+            code: "QS605EW0002",
+            name: "A Agriculture, forestry and fishing",
+            slug: "a-agriculture-forestry-and-fishing",
+          },
+          {
+            code: "QS605EW0003",
+            name: "B Mining and quarrying",
+            slug: "b-mining-and-quarrying",
+          },
+          {
+            code: "QS605EW0004",
+            name: "C Manufacturing",
+            slug: "c-manufacturing",
+          },
+          {
+            code: "QS605EW0005",
+            name: "C10-12 Manufacturing: Food, beverages and tobacco",
+            slug: "c10-12-manufacturing-food-beverages-and-tobacco",
+          },
+          {
+            code: "QS605EW0006",
+            name: "C13-15 Manufacturing: Textiles, wearing apparel and leather and related products",
+            slug: "c13-15-manufacturing-textiles-wearing-apparel-and-leather-and-related-products",
+          },
+          {
+            code: "QS605EW0007",
+            name: "C16,17 Manufacturing: Wood, paper and paper products",
+            slug: "c16-17-manufacturing-wood-paper-and-paper-products",
+          },
+          {
+            code: "QS605EW0008",
+            name: "C19-22 Manufacturing: Chemicals, chemical products, rubber and plastic",
+            slug: "c19-22-manufacturing-chemicals-chemical-products-rubber-and-plastic",
+          },
+          {
+            code: "QS605EW0009",
+            name: "C23-25 Manufacturing: Low tech",
+            slug: "c23-25-manufacturing-low-tech",
+          },
+          {
+            code: "QS605EW0010",
+            name: "C26-30 Manufacturing: High tech",
+            slug: "c26-30-manufacturing-high-tech",
+          },
+          {
+            code: "QS605EW0011",
+            name: "C18, 31, 32 Manufacturing: Other",
+            slug: "c18-31-32-manufacturing-other",
+          },
+          {
+            code: "QS605EW0012",
+            name: "D Electricity, gas, steam and air conditioning supply",
+            slug: "d-electricity-gas-steam-and-air-conditioning-supply",
+          },
+          {
+            code: "QS605EW0013",
+            name: "E Water supply, sewerage, waste management and remediation activities",
+            slug: "e-water-supply-sewerage-waste-management-and-remediation-activities",
+          },
+          {
+            code: "QS605EW0014",
+            name: "F Construction",
+            slug: "f-construction",
+          },
+          {
+            code: "QS605EW0015",
+            name: "G Wholesale and retail trade; repair of motor vehicles and motor cycles",
+            slug: "g-wholesale-and-retail-trade-repair-of-motor-vehicles-and-motor-cycles",
+          },
+          {
+            code: "QS605EW0016",
+            name: "H Transport and storage",
+            slug: "h-transport-and-storage",
+          },
+          {
+            code: "QS605EW0017",
+            name: "I Accommodation and food service activities",
+            slug: "i-accommodation-and-food-service-activities",
+          },
+          {
+            code: "QS605EW0018",
+            name: "J Information and communication",
+            slug: "j-information-and-communication",
+          },
+          {
+            code: "QS605EW0019",
+            name: "K Financial and insurance activities",
+            slug: "k-financial-and-insurance-activities",
+          },
+          {
+            code: "QS605EW0020",
+            name: "L Real estate activities",
+            slug: "l-real-estate-activities",
+          },
+          {
+            code: "QS605EW0021",
+            name: "M Professional, scientific and technical activities",
+            slug: "m-professional-scientific-and-technical-activities",
+          },
+          {
+            code: "QS605EW0022",
+            name: "N Administrative and support service activities",
+            slug: "n-administrative-and-support-service-activities",
+          },
+          {
+            code: "QS605EW0023",
+            name: "O Public administration and defence; compulsory social security",
+            slug: "o-public-administration-and-defence-compulsory-social-security",
+          },
+          {
+            code: "QS605EW0024",
+            name: "P Education",
+            slug: "p-education",
+          },
+          {
+            code: "QS605EW0025",
+            name: "Q Human health and social work activities",
+            slug: "q-human-health-and-social-work-activities",
+          },
+          {
+            code: "QS605EW0026",
+            name: "R,S Arts, entertainment and recreation; other service activities",
+            slug: "r-s-arts-entertainment-and-recreation-other-service-activities",
+          },
+          {
+            code: "QS605EW0027",
+            name: "T Activities of households as employers; undifferentiated goods - and services - producing activities of households for own use",
+            slug: "t-activities-of-households-as-employers-undifferentiated-goods-and-services-producing-activities-of-households-for-own-use",
+          },
+          {
+            code: "QS605EW0028",
+            name: "U Activities of extraterritorial organisations and bodies",
+            slug: "u-activities-of-extraterritorial-organisations-and-bodies",
+          },
+        ],
+        code: "QS605EW",
+        name: "Sector",
+        slug: "sector",
+        desc: "Types of sectors people who have a job or their last job worked in.",
+        total: {
+          code: "QS605EW0001",
+          name: "All categories: Industry",
+          slug: "all-categories-industry",
+        },
+        units: "People (usual residents)",
+      },
+      {
+        categories: [
+          {
+            code: "QS606EW0002",
+            name: "Managers, directors and senior officials",
+            slug: "managers-directors-and-senior-officials",
+          },
+          {
+            code: "QS606EW0003",
+            name: "Managers, directors and senior officials;     Corporate managers and directors",
+            slug: "managers-directors-and-senior-officials-corporate-managers-and-directors",
+          },
+          {
+            code: "QS606EW0004",
+            name: "Managers, directors and senior officials;     Corporate managers and directors;         Chief Executives and Senior Officials",
+            slug: "managers-directors-and-senior-officials-corporate-managers-and-directors-chief-executives-and-senior-officials",
+          },
+          {
+            code: "QS606EW0005",
+            name: "Managers, directors and senior officials;     Corporate managers and directors;         Production Managers and Directors",
+            slug: "managers-directors-and-senior-officials-corporate-managers-and-directors-production-managers-and-directors",
+          },
+          {
+            code: "QS606EW0006",
+            name: "Managers, directors and senior officials;     Corporate managers and directors;         Functional Managers and Directors",
+            slug: "managers-directors-and-senior-officials-corporate-managers-and-directors-functional-managers-and-directors",
+          },
+          {
+            code: "QS606EW0007",
+            name: "Managers, directors and senior officials;     Corporate managers and directors;         Financial Institution Managers and Directors",
+            slug: "managers-directors-and-senior-officials-corporate-managers-and-directors-financial-institution-managers-and-directors",
+          },
+          {
+            code: "QS606EW0008",
+            name: "Managers, directors and senior officials;     Corporate managers and directors;         Managers and Directors in Transport and Logistics",
+            slug: "managers-directors-and-senior-officials-corporate-managers-and-directors-managers-and-directors-in-transport-and-logistics",
+          },
+          {
+            code: "QS606EW0009",
+            name: "Managers, directors and senior officials;     Corporate managers and directors;         Senior Officers in Protective Services",
+            slug: "managers-directors-and-senior-officials-corporate-managers-and-directors-senior-officers-in-protective-services",
+          },
+          {
+            code: "QS606EW0010",
+            name: "Managers, directors and senior officials;     Corporate managers and directors;         Health and Social Services Managers and Directors",
+            slug: "managers-directors-and-senior-officials-corporate-managers-and-directors-health-and-social-services-managers-and-directors",
+          },
+          {
+            code: "QS606EW0011",
+            name: "Managers, directors and senior officials;     Corporate managers and directors;         Managers and Directors in Retail and Wholesale",
+            slug: "managers-directors-and-senior-officials-corporate-managers-and-directors-managers-and-directors-in-retail-and-wholesale",
+          },
+          {
+            code: "QS606EW0012",
+            name: "Managers, directors and senior officials;     Other managers and proprietors",
+            slug: "managers-directors-and-senior-officials-other-managers-and-proprietors",
+          },
+          {
+            code: "QS606EW0013",
+            name: "Managers, directors and senior officials;     Other managers and proprietors;         Managers and Proprietors in Agriculture Related Services",
+            slug: "managers-directors-and-senior-officials-other-managers-and-proprietors-managers-and-proprietors-in-agriculture-related-services",
+          },
+          {
+            code: "QS606EW0014",
+            name: "Managers, directors and senior officials;     Other managers and proprietors;         Managers and Proprietors in Hospitality and Leisure Services",
+            slug: "managers-directors-and-senior-officials-other-managers-and-proprietors-managers-and-proprietors-in-hospitality-and-leisure-services",
+          },
+          {
+            code: "QS606EW0015",
+            name: "Managers, directors and senior officials;     Other managers and proprietors;         Managers and Proprietors in Health and Care Services",
+            slug: "managers-directors-and-senior-officials-other-managers-and-proprietors-managers-and-proprietors-in-health-and-care-services",
+          },
+          {
+            code: "QS606EW0016",
+            name: "Managers, directors and senior officials;     Other managers and proprietors;         Managers and Proprietors in Other Services",
+            slug: "managers-directors-and-senior-officials-other-managers-and-proprietors-managers-and-proprietors-in-other-services",
+          },
+          {
+            code: "QS606EW0017",
+            name: "Professional occupations",
+            slug: "professional-occupations",
+          },
+          {
+            code: "QS606EW0018",
+            name: "Professional occupations;     Science, research, engineering and technology professionals",
+            slug: "professional-occupations-science-research-engineering-and-technology-professionals",
+          },
+          {
+            code: "QS606EW0019",
+            name: "Professional occupations;     Science, research, engineering and technology professionals;         Natural and Social Science Professionals",
+            slug: "professional-occupations-science-research-engineering-and-technology-professionals-natural-and-social-science-professionals",
+          },
+          {
+            code: "QS606EW0020",
+            name: "Professional occupations;     Science, research, engineering and technology professionals;         Engineering Professionals",
+            slug: "professional-occupations-science-research-engineering-and-technology-professionals-engineering-professionals",
+          },
+          {
+            code: "QS606EW0021",
+            name: "Professional occupations;     Science, research, engineering and technology professionals;         Information Technology and Telecommunications Professionals",
+            slug: "professional-occupations-science-research-engineering-and-technology-professionals-information-technology-and-telecommunications-professionals",
+          },
+          {
+            code: "QS606EW0022",
+            name: "Professional occupations;     Science, research, engineering and technology professionals;         Conservation and Environment Professionals",
+            slug: "professional-occupations-science-research-engineering-and-technology-professionals-conservation-and-environment-professionals",
+          },
+          {
+            code: "QS606EW0023",
+            name: "Professional occupations;     Science, research, engineering and technology professionals;         Research and Development Managers ",
+            slug: "professional-occupations-science-research-engineering-and-technology-professionals-research-and-development-managers",
+          },
+          {
+            code: "QS606EW0024",
+            name: "Professional occupations;     Health professionals",
+            slug: "professional-occupations-health-professionals",
+          },
+          {
+            code: "QS606EW0025",
+            name: "Professional occupations;     Health professionals;         Health Professionals",
+            slug: "professional-occupations-health-professionals-health-professionals",
+          },
+          {
+            code: "QS606EW0026",
+            name: "Professional occupations;     Health professionals;         Therapy Professionals",
+            slug: "professional-occupations-health-professionals-therapy-professionals",
+          },
+          {
+            code: "QS606EW0027",
+            name: "Professional occupations;     Health professionals;         Nursing and Midwifery Professionals",
+            slug: "professional-occupations-health-professionals-nursing-and-midwifery-professionals",
+          },
+          {
+            code: "QS606EW0028",
+            name: "Professional occupations;     Teaching and educational professionals",
+            slug: "professional-occupations-teaching-and-educational-professionals",
+          },
+          {
+            code: "QS606EW0029",
+            name: "Professional occupations;     Teaching and educational professionals;         Teaching and Educational Professionals",
+            slug: "professional-occupations-teaching-and-educational-professionals-teaching-and-educational-professionals",
+          },
+          {
+            code: "QS606EW0030",
+            name: "Professional occupations;     Business, media and public service professionals",
+            slug: "professional-occupations-business-media-and-public-service-professionals",
+          },
+          {
+            code: "QS606EW0031",
+            name: "Professional occupations;     Business, media and public service professionals;         Legal Professionals",
+            slug: "professional-occupations-business-media-and-public-service-professionals-legal-professionals",
+          },
+          {
+            code: "QS606EW0032",
+            name: "Professional occupations;     Business, media and public service professionals;         Business, Research and Administrative Professionals",
+            slug: "professional-occupations-business-media-and-public-service-professionals-business-research-and-administrative-professionals",
+          },
+          {
+            code: "QS606EW0033",
+            name: "Professional occupations;     Business, media and public service professionals;         Architects, Town Planners and Surveyors",
+            slug: "professional-occupations-business-media-and-public-service-professionals-architects-town-planners-and-surveyors",
+          },
+          {
+            code: "QS606EW0034",
+            name: "Professional occupations;     Business, media and public service professionals;         Welfare Professionals",
+            slug: "professional-occupations-business-media-and-public-service-professionals-welfare-professionals",
+          },
+          {
+            code: "QS606EW0035",
+            name: "Professional occupations;     Business, media and public service professionals;         Librarians and Related Professionals",
+            slug: "professional-occupations-business-media-and-public-service-professionals-librarians-and-related-professionals",
+          },
+          {
+            code: "QS606EW0036",
+            name: "Professional occupations;     Business, media and public service professionals;         Quality and Regulatory Professionals",
+            slug: "professional-occupations-business-media-and-public-service-professionals-quality-and-regulatory-professionals",
+          },
+          {
+            code: "QS606EW0037",
+            name: "Professional occupations;     Business, media and public service professionals;         Media Professionals",
+            slug: "professional-occupations-business-media-and-public-service-professionals-media-professionals",
+          },
+          {
+            code: "QS606EW0038",
+            name: "Associate professional and technical occupations",
+            slug: "associate-professional-and-technical-occupations",
+          },
+          {
+            code: "QS606EW0039",
+            name: "Associate professional and technical occupations;     Science, engineering and technology associate professionals",
+            slug: "associate-professional-and-technical-occupations-science-engineering-and-technology-associate-professionals",
+          },
+          {
+            code: "QS606EW0040",
+            name: "Associate professional and technical occupations;     Science, engineering and technology associate professionals;         Science, Engineering and Production Technicians",
+            slug: "associate-professional-and-technical-occupations-science-engineering-and-technology-associate-professionals-science-engineering-and-production-technicians",
+          },
+          {
+            code: "QS606EW0041",
+            name: "Associate professional and technical occupations;     Science, engineering and technology associate professionals;         Draughtspersons and Related Architectural Technicians",
+            slug: "associate-professional-and-technical-occupations-science-engineering-and-technology-associate-professionals-draughtspersons-and-related-architectural-technicians",
+          },
+          {
+            code: "QS606EW0042",
+            name: "Associate professional and technical occupations;     Science, engineering and technology associate professionals;         Information Technology Technicians",
+            slug: "associate-professional-and-technical-occupations-science-engineering-and-technology-associate-professionals-information-technology-technicians",
+          },
+          {
+            code: "QS606EW0043",
+            name: "Associate professional and technical occupations;     Health and social care associate professionals",
+            slug: "associate-professional-and-technical-occupations-health-and-social-care-associate-professionals",
+          },
+          {
+            code: "QS606EW0044",
+            name: "Associate professional and technical occupations;     Health and social care associate professionals;         Health Associate Professionals",
+            slug: "associate-professional-and-technical-occupations-health-and-social-care-associate-professionals-health-associate-professionals",
+          },
+          {
+            code: "QS606EW0045",
+            name: "Associate professional and technical occupations;     Health and social care associate professionals;         Welfare and Housing Associate Professionals",
+            slug: "associate-professional-and-technical-occupations-health-and-social-care-associate-professionals-welfare-and-housing-associate-professionals",
+          },
+          {
+            code: "QS606EW0046",
+            name: "Associate professional and technical occupations;     Protective service occupations",
+            slug: "associate-professional-and-technical-occupations-protective-service-occupations",
+          },
+          {
+            code: "QS606EW0047",
+            name: "Associate professional and technical occupations;     Protective service occupations;         Protective Service Occupations",
+            slug: "associate-professional-and-technical-occupations-protective-service-occupations-protective-service-occupations",
+          },
+          {
+            code: "QS606EW0048",
+            name: "Associate professional and technical occupations;     Culture, media and sports occupations",
+            slug: "associate-professional-and-technical-occupations-culture-media-and-sports-occupations",
+          },
+          {
+            code: "QS606EW0049",
+            name: "Associate professional and technical occupations;     Culture, media and sports occupations;         Artistic, Literary and Media Occupations",
+            slug: "associate-professional-and-technical-occupations-culture-media-and-sports-occupations-artistic-literary-and-media-occupations",
+          },
+          {
+            code: "QS606EW0050",
+            name: "Associate professional and technical occupations;     Culture, media and sports occupations;         Design Occupations",
+            slug: "associate-professional-and-technical-occupations-culture-media-and-sports-occupations-design-occupations",
+          },
+          {
+            code: "QS606EW0051",
+            name: "Associate professional and technical occupations;     Culture, media and sports occupations;         Sports and Fitness Occupations",
+            slug: "associate-professional-and-technical-occupations-culture-media-and-sports-occupations-sports-and-fitness-occupations",
+          },
+          {
+            code: "QS606EW0052",
+            name: "Associate professional and technical occupations;     Business and public service associate professionals",
+            slug: "associate-professional-and-technical-occupations-business-and-public-service-associate-professionals",
+          },
+          {
+            code: "QS606EW0053",
+            name: "Associate professional and technical occupations;     Business and public service associate professionals;         Transport Associate Professionals",
+            slug: "associate-professional-and-technical-occupations-business-and-public-service-associate-professionals-transport-associate-professionals",
+          },
+          {
+            code: "QS606EW0054",
+            name: "Associate professional and technical occupations;     Business and public service associate professionals;         Legal Associate Professionals",
+            slug: "associate-professional-and-technical-occupations-business-and-public-service-associate-professionals-legal-associate-professionals",
+          },
+          {
+            code: "QS606EW0055",
+            name: "Associate professional and technical occupations;     Business and public service associate professionals;         Business, Finance and Related Associate Professionals",
+            slug: "associate-professional-and-technical-occupations-business-and-public-service-associate-professionals-business-finance-and-related-associate-professionals",
+          },
+          {
+            code: "QS606EW0056",
+            name: "Associate professional and technical occupations;     Business and public service associate professionals;         Sales, Marketing and Related Associate Professionals",
+            slug: "associate-professional-and-technical-occupations-business-and-public-service-associate-professionals-sales-marketing-and-related-associate-professionals",
+          },
+          {
+            code: "QS606EW0057",
+            name: "Associate professional and technical occupations;     Business and public service associate professionals;         Conservation and Environmental associate professionals",
+            slug: "associate-professional-and-technical-occupations-business-and-public-service-associate-professionals-conservation-and-environmental-associate-professionals",
+          },
+          {
+            code: "QS606EW0058",
+            name: "Associate professional and technical occupations;     Business and public service associate professionals;         Public Services and Other Associate Professionals",
+            slug: "associate-professional-and-technical-occupations-business-and-public-service-associate-professionals-public-services-and-other-associate-professionals",
+          },
+          {
+            code: "QS606EW0059",
+            name: "Administrative and secretarial occupations",
+            slug: "administrative-and-secretarial-occupations",
+          },
+          {
+            code: "QS606EW0060",
+            name: "Administrative and secretarial occupations;     Administrative occupations",
+            slug: "administrative-and-secretarial-occupations-administrative-occupations",
+          },
+          {
+            code: "QS606EW0061",
+            name: "Administrative and secretarial occupations;     Administrative occupations;         Administrative Occupations: Government and Related Organisations",
+            slug: "administrative-and-secretarial-occupations-administrative-occupations-administrative-occupations-government-and-related-organisations",
+          },
+          {
+            code: "QS606EW0062",
+            name: "Administrative and secretarial occupations;     Administrative occupations;         Administrative Occupations: Finance",
+            slug: "administrative-and-secretarial-occupations-administrative-occupations-administrative-occupations-finance",
+          },
+          {
+            code: "QS606EW0063",
+            name: "Administrative and secretarial occupations;     Administrative occupations;         Administrative Occupations: Records",
+            slug: "administrative-and-secretarial-occupations-administrative-occupations-administrative-occupations-records",
+          },
+          {
+            code: "QS606EW0064",
+            name: "Administrative and secretarial occupations;     Administrative occupations;         Other Administrative Occupations",
+            slug: "administrative-and-secretarial-occupations-administrative-occupations-other-administrative-occupations",
+          },
+          {
+            code: "QS606EW0065",
+            name: "Administrative and secretarial occupations;     Administrative occupations;         Administrative Occupations: Office Managers and Supervisors",
+            slug: "administrative-and-secretarial-occupations-administrative-occupations-administrative-occupations-office-managers-and-supervisors",
+          },
+          {
+            code: "QS606EW0066",
+            name: "Administrative and secretarial occupations;     Secretarial and related occupations",
+            slug: "administrative-and-secretarial-occupations-secretarial-and-related-occupations",
+          },
+          {
+            code: "QS606EW0067",
+            name: "Administrative and secretarial occupations;     Secretarial and related occupations;         Secretarial and Related Occupations",
+            slug: "administrative-and-secretarial-occupations-secretarial-and-related-occupations-secretarial-and-related-occupations",
+          },
+          {
+            code: "QS606EW0068",
+            name: "Skilled trades occupations",
+            slug: "skilled-trades-occupations",
+          },
+          {
+            code: "QS606EW0069",
+            name: "Skilled trades occupations;     Skilled agricultural and related trades",
+            slug: "skilled-trades-occupations-skilled-agricultural-and-related-trades",
+          },
+          {
+            code: "QS606EW0070",
+            name: "Skilled trades occupations;     Skilled agricultural and related trades;         Agricultural and Related Trades",
+            slug: "skilled-trades-occupations-skilled-agricultural-and-related-trades-agricultural-and-related-trades",
+          },
+          {
+            code: "QS606EW0071",
+            name: "Skilled trades occupations;     Skilled metal, electrical and electronic trades",
+            slug: "skilled-trades-occupations-skilled-metal-electrical-and-electronic-trades",
+          },
+          {
+            code: "QS606EW0072",
+            name: "Skilled trades occupations;     Skilled metal, electrical and electronic trades;         Metal Forming, Welding and Related Trades",
+            slug: "skilled-trades-occupations-skilled-metal-electrical-and-electronic-trades-metal-forming-welding-and-related-trades",
+          },
+          {
+            code: "QS606EW0073",
+            name: "Skilled trades occupations;     Skilled metal, electrical and electronic trades;         Metal Machining, Fitting and Instrument Making Trades",
+            slug: "skilled-trades-occupations-skilled-metal-electrical-and-electronic-trades-metal-machining-fitting-and-instrument-making-trades",
+          },
+          {
+            code: "QS606EW0074",
+            name: "Skilled trades occupations;     Skilled metal, electrical and electronic trades;         Vehicle Trades",
+            slug: "skilled-trades-occupations-skilled-metal-electrical-and-electronic-trades-vehicle-trades",
+          },
+          {
+            code: "QS606EW0075",
+            name: "Skilled trades occupations;     Skilled metal, electrical and electronic trades;         Electrical and Electronic Trades",
+            slug: "skilled-trades-occupations-skilled-metal-electrical-and-electronic-trades-electrical-and-electronic-trades",
+          },
+          {
+            code: "QS606EW0076",
+            name: "Skilled trades occupations;     Skilled metal, electrical and electronic trades;         Skilled Metal, Electrical and Electronic Trades Supervisors",
+            slug: "skilled-trades-occupations-skilled-metal-electrical-and-electronic-trades-skilled-metal-electrical-and-electronic-trades-supervisors",
+          },
+          {
+            code: "QS606EW0077",
+            name: "Skilled trades occupations;     Skilled construction and building trades",
+            slug: "skilled-trades-occupations-skilled-construction-and-building-trades",
+          },
+          {
+            code: "QS606EW0078",
+            name: "Skilled trades occupations;     Skilled construction and building trades;         Construction and Building Trades",
+            slug: "skilled-trades-occupations-skilled-construction-and-building-trades-construction-and-building-trades",
+          },
+          {
+            code: "QS606EW0079",
+            name: "Skilled trades occupations;     Skilled construction and building trades;         Building Finishing Trades",
+            slug: "skilled-trades-occupations-skilled-construction-and-building-trades-building-finishing-trades",
+          },
+          {
+            code: "QS606EW0080",
+            name: "Skilled trades occupations;     Skilled construction and building trades;         Construction and Building Trades Supervisors",
+            slug: "skilled-trades-occupations-skilled-construction-and-building-trades-construction-and-building-trades-supervisors",
+          },
+          {
+            code: "QS606EW0081",
+            name: "Skilled trades occupations;     Textiles, printing and other skilled trades",
+            slug: "skilled-trades-occupations-textiles-printing-and-other-skilled-trades",
+          },
+          {
+            code: "QS606EW0082",
+            name: "Skilled trades occupations;     Textiles, printing and other skilled trades;         Textiles and Garments Trades",
+            slug: "skilled-trades-occupations-textiles-printing-and-other-skilled-trades-textiles-and-garments-trades",
+          },
+          {
+            code: "QS606EW0083",
+            name: "Skilled trades occupations;     Textiles, printing and other skilled trades;         Printing Trades",
+            slug: "skilled-trades-occupations-textiles-printing-and-other-skilled-trades-printing-trades",
+          },
+          {
+            code: "QS606EW0084",
+            name: "Skilled trades occupations;     Textiles, printing and other skilled trades;         Food Preparation and Hospitality Trades",
+            slug: "skilled-trades-occupations-textiles-printing-and-other-skilled-trades-food-preparation-and-hospitality-trades",
+          },
+          {
+            code: "QS606EW0085",
+            name: "Skilled trades occupations;     Textiles, printing and other skilled trades;         Other Skilled Trades",
+            slug: "skilled-trades-occupations-textiles-printing-and-other-skilled-trades-other-skilled-trades",
+          },
+          {
+            code: "QS606EW0086",
+            name: "Caring, leisure and other service occupations",
+            slug: "caring-leisure-and-other-service-occupations",
+          },
+          {
+            code: "QS606EW0087",
+            name: "Caring, leisure and other service occupations;     Caring personal service occupations",
+            slug: "caring-leisure-and-other-service-occupations-caring-personal-service-occupations",
+          },
+          {
+            code: "QS606EW0088",
+            name: "Caring, leisure and other service occupations;     Caring personal service occupations;         Childcare and Related Personal Services",
+            slug: "caring-leisure-and-other-service-occupations-caring-personal-service-occupations-childcare-and-related-personal-services",
+          },
+          {
+            code: "QS606EW0089",
+            name: "Caring, leisure and other service occupations;     Caring personal service occupations;         Animal Care and Control Services",
+            slug: "caring-leisure-and-other-service-occupations-caring-personal-service-occupations-animal-care-and-control-services",
+          },
+          {
+            code: "QS606EW0090",
+            name: "Caring, leisure and other service occupations;     Caring personal service occupations;         Caring Personal Services",
+            slug: "caring-leisure-and-other-service-occupations-caring-personal-service-occupations-caring-personal-services",
+          },
+          {
+            code: "QS606EW0091",
+            name: "Caring, leisure and other service occupations;     Leisure, travel and related personal service occupations",
+            slug: "caring-leisure-and-other-service-occupations-leisure-travel-and-related-personal-service-occupations",
+          },
+          {
+            code: "QS606EW0092",
+            name: "Caring, leisure and other service occupations;     Leisure, travel and related personal service occupations;         Leisure and Travel Services",
+            slug: "caring-leisure-and-other-service-occupations-leisure-travel-and-related-personal-service-occupations-leisure-and-travel-services",
+          },
+          {
+            code: "QS606EW0093",
+            name: "Caring, leisure and other service occupations;     Leisure, travel and related personal service occupations;         Hairdressers and Related Services",
+            slug: "caring-leisure-and-other-service-occupations-leisure-travel-and-related-personal-service-occupations-hairdressers-and-related-services",
+          },
+          {
+            code: "QS606EW0094",
+            name: "Caring, leisure and other service occupations;     Leisure, travel and related personal service occupations;         Housekeeping and Related Services",
+            slug: "caring-leisure-and-other-service-occupations-leisure-travel-and-related-personal-service-occupations-housekeeping-and-related-services",
+          },
+          {
+            code: "QS606EW0095",
+            name: "Caring, leisure and other service occupations;     Leisure, travel and related personal service occupations;         Cleaning and Housekeeping Managers and Supervisors",
+            slug: "caring-leisure-and-other-service-occupations-leisure-travel-and-related-personal-service-occupations-cleaning-and-housekeeping-managers-and-supervisors",
+          },
+          {
+            code: "QS606EW0096",
+            name: "Sales and customer service occupations",
+            slug: "sales-and-customer-service-occupations",
+          },
+          {
+            code: "QS606EW0097",
+            name: "Sales and customer service occupations;     Sales occupations",
+            slug: "sales-and-customer-service-occupations-sales-occupations",
+          },
+          {
+            code: "QS606EW0098",
+            name: "Sales and customer service occupations;     Sales occupations;         Sales Assistants and Retail Cashiers",
+            slug: "sales-and-customer-service-occupations-sales-occupations-sales-assistants-and-retail-cashiers",
+          },
+          {
+            code: "QS606EW0099",
+            name: "Sales and customer service occupations;     Sales occupations;         Sales Related Occupations",
+            slug: "sales-and-customer-service-occupations-sales-occupations-sales-related-occupations",
+          },
+          {
+            code: "QS606EW0100",
+            name: "Sales and customer service occupations;     Sales occupations;         Sales Supervisors",
+            slug: "sales-and-customer-service-occupations-sales-occupations-sales-supervisors",
+          },
+          {
+            code: "QS606EW0101",
+            name: "Sales and customer service occupations;     Customer service occupations",
+            slug: "sales-and-customer-service-occupations-customer-service-occupations",
+          },
+          {
+            code: "QS606EW0102",
+            name: "Sales and customer service occupations;     Customer service occupations;         Customer Service Occupations",
+            slug: "sales-and-customer-service-occupations-customer-service-occupations-customer-service-occupations",
+          },
+          {
+            code: "QS606EW0103",
+            name: "Sales and customer service occupations;     Customer service occupations;         Customer Service Managers and Supervisors",
+            slug: "sales-and-customer-service-occupations-customer-service-occupations-customer-service-managers-and-supervisors",
+          },
+          {
+            code: "QS606EW0104",
+            name: "Process, plant and machine operatives",
+            slug: "process-plant-and-machine-operatives",
+          },
+          {
+            code: "QS606EW0105",
+            name: "Process, plant and machine operatives;     Process, plant and machine operatives",
+            slug: "process-plant-and-machine-operatives-process-plant-and-machine-operatives",
+          },
+          {
+            code: "QS606EW0106",
+            name: "Process, plant and machine operatives;     Process, plant and machine operatives;         Process Operatives",
+            slug: "process-plant-and-machine-operatives-process-plant-and-machine-operatives-process-operatives",
+          },
+          {
+            code: "QS606EW0107",
+            name: "Process, plant and machine operatives;     Process, plant and machine operatives;         Plant and Machine Operatives",
+            slug: "process-plant-and-machine-operatives-process-plant-and-machine-operatives-plant-and-machine-operatives",
+          },
+          {
+            code: "QS606EW0108",
+            name: "Process, plant and machine operatives;     Process, plant and machine operatives;         Assemblers and Routine Operatives",
+            slug: "process-plant-and-machine-operatives-process-plant-and-machine-operatives-assemblers-and-routine-operatives",
+          },
+          {
+            code: "QS606EW0109",
+            name: "Process, plant and machine operatives;     Process, plant and machine operatives;         Construction Operatives",
+            slug: "process-plant-and-machine-operatives-process-plant-and-machine-operatives-construction-operatives",
+          },
+          {
+            code: "QS606EW0110",
+            name: "Process, plant and machine operatives;     Transport and mobile machine drivers and operatives",
+            slug: "process-plant-and-machine-operatives-transport-and-mobile-machine-drivers-and-operatives",
+          },
+          {
+            code: "QS606EW0111",
+            name: "Process, plant and machine operatives;     Transport and mobile machine drivers and operatives;         Road Transport Drivers",
+            slug: "process-plant-and-machine-operatives-transport-and-mobile-machine-drivers-and-operatives-road-transport-drivers",
+          },
+          {
+            code: "QS606EW0112",
+            name: "Process, plant and machine operatives;     Transport and mobile machine drivers and operatives;         Mobile Machine Drivers and Operatives",
+            slug: "process-plant-and-machine-operatives-transport-and-mobile-machine-drivers-and-operatives-mobile-machine-drivers-and-operatives",
+          },
+          {
+            code: "QS606EW0113",
+            name: "Process, plant and machine operatives;     Transport and mobile machine drivers and operatives;         Other Drivers and Transport Operatives",
+            slug: "process-plant-and-machine-operatives-transport-and-mobile-machine-drivers-and-operatives-other-drivers-and-transport-operatives",
+          },
+          {
+            code: "QS606EW0114",
+            name: "Elementary occupations",
+            slug: "elementary-occupations",
+          },
+          {
+            code: "QS606EW0115",
+            name: "Elementary occupations;     Elementary trades and related occupations",
+            slug: "elementary-occupations-elementary-trades-and-related-occupations",
+          },
+          {
+            code: "QS606EW0116",
+            name: "Elementary occupations;     Elementary trades and related occupations;         Elementary Agricultural Occupations",
+            slug: "elementary-occupations-elementary-trades-and-related-occupations-elementary-agricultural-occupations",
+          },
+          {
+            code: "QS606EW0117",
+            name: "Elementary occupations;     Elementary trades and related occupations;         Elementary Construction Occupations",
+            slug: "elementary-occupations-elementary-trades-and-related-occupations-elementary-construction-occupations",
+          },
+          {
+            code: "QS606EW0118",
+            name: "Elementary occupations;     Elementary trades and related occupations;         Elementary Process Plant Occupations",
+            slug: "elementary-occupations-elementary-trades-and-related-occupations-elementary-process-plant-occupations",
+          },
+          {
+            code: "QS606EW0119",
+            name: "Elementary occupations;     Elementary administration and service occupations",
+            slug: "elementary-occupations-elementary-administration-and-service-occupations",
+          },
+          {
+            code: "QS606EW0120",
+            name: "Elementary occupations;     Elementary administration and service occupations;         Elementary Administration Occupations",
+            slug: "elementary-occupations-elementary-administration-and-service-occupations-elementary-administration-occupations",
+          },
+          {
+            code: "QS606EW0121",
+            name: "Elementary occupations;     Elementary administration and service occupations;         Elementary Cleaning Occupations",
+            slug: "elementary-occupations-elementary-administration-and-service-occupations-elementary-cleaning-occupations",
+          },
+          {
+            code: "QS606EW0122",
+            name: "Elementary occupations;     Elementary administration and service occupations;         Elementary Security Occupations",
+            slug: "elementary-occupations-elementary-administration-and-service-occupations-elementary-security-occupations",
+          },
+          {
+            code: "QS606EW0123",
+            name: "Elementary occupations;     Elementary administration and service occupations;         Elementary Sales Occupations",
+            slug: "elementary-occupations-elementary-administration-and-service-occupations-elementary-sales-occupations",
+          },
+          {
+            code: "QS606EW0124",
+            name: "Elementary occupations;     Elementary administration and service occupations;         Elementary Storage Occupations",
+            slug: "elementary-occupations-elementary-administration-and-service-occupations-elementary-storage-occupations",
+          },
+          {
+            code: "QS606EW0125",
+            name: "Elementary occupations;     Elementary administration and service occupations;         Other Elementary Services Occupations",
+            slug: "elementary-occupations-elementary-administration-and-service-occupations-other-elementary-services-occupations",
+          },
+        ],
+        code: "QS606EW",
+        name: "Job",
+        slug: "job",
+        desc: "The types of jobs people do",
+        total: {
+          code: "QS606EW0001",
+          name: "All categories: Occupation",
+          slug: "all-categories-occupation",
+        },
+        units: "People (usual residents)",
+      },
+      {
+        categories: [
+          {
+            code: "QS701EW0002",
+            name: "Work mainly at or from home",
+            slug: "work-mainly-at-or-from-home",
+          },
+          {
+            code: "QS701EW0003",
+            name: "Underground, metro, light rail, tram",
+            slug: "underground-metro-light-rail-tram",
+          },
+          {
+            code: "QS701EW0004",
+            name: "Train",
+            slug: "train",
+          },
+          {
+            code: "QS701EW0005",
+            name: "Bus, minibus or coach",
+            slug: "bus-minibus-or-coach",
+          },
+          {
+            code: "QS701EW0006",
+            name: "Taxi",
+            slug: "taxi",
+          },
+          {
+            code: "QS701EW0007",
+            name: "Motorcycle, scooter or moped",
+            slug: "motorcycle-scooter-or-moped",
+          },
+          {
+            code: "QS701EW0008",
+            name: "Driving a car or van",
+            slug: "driving-a-car-or-van",
+          },
+          {
+            code: "QS701EW0009",
+            name: "Passenger in a car or van",
+            slug: "passenger-in-a-car-or-van",
+          },
+          {
+            code: "QS701EW0010",
+            name: "Bicycle",
+            slug: "bicycle",
+          },
+          {
+            code: "QS701EW0011",
+            name: "On foot",
+            slug: "on-foot",
+          },
+          {
+            code: "QS701EW0012",
+            name: "Other method of travel to work",
+            slug: "other-method-of-travel-to-work",
+          },
+          {
+            code: "QS701EW0013",
+            name: "Not in employment",
+            slug: "not-in-employment",
+          },
+        ],
+        code: "QS701EW",
+        name: "Travel to work",
+        slug: "travel-to-work",
+        desc: "Types of transport people use to travel to work.",
+        total: {
+          code: "QS701EW0001",
+          name: "All categories: Method of travel to work",
+          slug: "all-categories-method-of-travel-to-work",
+        },
+        units: "People (usual residents)",
+      },
+    ],
+  },
 ];

--- a/src/model/censusdata/censusdata.js
+++ b/src/model/censusdata/censusdata.js
@@ -39,14 +39,11 @@ export function reset() {
   categoryCodeLookup = {};
 }
 
-export async function fetchAllDataForGeography(censusDataService, geographyCode, selectedGeography, overwriteCache) {
+export async function fetchAllDataForGeography(censusDataService, geographyCode, overwriteCache) {
   const data = await censusDataService.fetchAllDataForGeography(geographyCode);
-  //if E&W data - call on app initialise
+  //if E&W data (call on app initialise)
   if (geographyCode == config.eAndWGeoCode) {
     englandAndWalesData.set(data);
-  } else if (selectedGeography) {
-    //write data to selectedGeographyData store
-    selectedGeographyData.set(data);
   } else if (overwriteCache) {
     //overwrite dataByGeography store
     dataByGeography.set(data);

--- a/src/model/censusdata/censusdata.js
+++ b/src/model/censusdata/censusdata.js
@@ -4,6 +4,7 @@ import { addNewGeoDataToCache } from "../utils";
 
 export let selectedGeographyData = writable(new Map());
 export let dataByGeography = writable(new Map());
+export let englandAndWalesData = writable(new Map())
 export let newDataByGeography = toggleable(false);
 
 export let censusTableStructureIsLoaded = writable(false);
@@ -37,9 +38,21 @@ export function reset() {
   categoryCodeLookup = {};
 }
 
-export async function fetchAllDataForGeography(censusDataService, geographyCode) {
+export async function fetchAllDataForGeography(censusDataService, geographyCode, selectedGeography, overwriteCache) {
   const data = await censusDataService.fetchAllDataForGeography(geographyCode);
-  selectedGeographyData.set(data);
+  //if E&W data - call on app initialise
+  if (geographyCode == "K04000001") {
+    englandAndWalesData.set(data)
+  } else if (selectedGeography){
+    //write data to selectedGeographyData store
+    selectedGeographyData.set(data);
+  } else if (overwriteCache) {
+    //overwrite dataByGeography store
+    dataByGeography.set(data);
+  } else {
+    //add to existing data in dataByGeography store
+    addNewGeoDataToCache(data);
+  }
 }
 
 export async function fetchSelectedDataForGeoType(censusDataService, geoType, categories, overwriteCache) {

--- a/src/model/censusdata/censusdata.js
+++ b/src/model/censusdata/censusdata.js
@@ -1,11 +1,11 @@
 import { writable, get } from "svelte/store";
 import { mapBBoxCodes, toggleable } from "./stores";
 import { addNewGeoDataToCache } from "../utils";
-import config from "../../config"
+import config from "../../config";
 
 export let selectedGeographyData = writable(new Map());
 export let dataByGeography = writable(new Map());
-export let englandAndWalesData = writable(new Map())
+export let englandAndWalesData = writable(new Map());
 export let newDataByGeography = toggleable(false);
 
 export let censusTableStructureIsLoaded = writable(false);
@@ -43,8 +43,8 @@ export async function fetchAllDataForGeography(censusDataService, geographyCode,
   const data = await censusDataService.fetchAllDataForGeography(geographyCode);
   //if E&W data - call on app initialise
   if (geographyCode == config.eAndWGeoCode) {
-    englandAndWalesData.set(data)
-  } else if (selectedGeography){
+    englandAndWalesData.set(data);
+  } else if (selectedGeography) {
     //write data to selectedGeographyData store
     selectedGeographyData.set(data);
   } else if (overwriteCache) {

--- a/src/model/censusdata/censusdata.js
+++ b/src/model/censusdata/censusdata.js
@@ -1,6 +1,7 @@
 import { writable, get } from "svelte/store";
 import { mapBBoxCodes, toggleable } from "./stores";
 import { addNewGeoDataToCache } from "../utils";
+import config from "../../config"
 
 export let selectedGeographyData = writable(new Map());
 export let dataByGeography = writable(new Map());
@@ -41,7 +42,7 @@ export function reset() {
 export async function fetchAllDataForGeography(censusDataService, geographyCode, selectedGeography, overwriteCache) {
   const data = await censusDataService.fetchAllDataForGeography(geographyCode);
   //if E&W data - call on app initialise
-  if (geographyCode == "K04000001") {
+  if (geographyCode == config.eAndWGeoCode) {
     englandAndWalesData.set(data)
   } else if (selectedGeography){
     //write data to selectedGeographyData store

--- a/src/model/censusdata/services/geodataApiDataService.js
+++ b/src/model/censusdata/services/geodataApiDataService.js
@@ -9,17 +9,7 @@ export default class GeodataApiDataService {
     const url = `${censusDataBaseUrl}?rows=${geographyCode}`;
     const response = await fetch(url);
     const string = await response.text();
-    let data = new Map();
-    csvParse(string, (row, i, cols) => {
-      cols.forEach((col, i) => {
-        if (i == 0) {
-          data.set("geographyCode", row[cols[0]]);
-        } else {
-          data.set(col, +row[col]);
-        }
-      });
-    });
-    return data;
+    return writeCsvDataToMapObj(string, geographyCode);
   }
 
   async fetchSelectedDataForGeographyType(geoType, categories) {

--- a/src/model/utils.js
+++ b/src/model/utils.js
@@ -11,7 +11,7 @@ export function getLegendSection(value, breakpoints) {
   return breakpoints.length;
 }
 
-export function writeCsvDataToMapObj(responseStr) {
+export function writeCsvDataToMapObj(responseStr, geographyCode) {
   let data = new Map();
   csvParse(responseStr, (row, i, cols) => {
     let geoDataMap = new Map();
@@ -20,7 +20,7 @@ export function writeCsvDataToMapObj(responseStr) {
         geoDataMap.set(col, +row[col]);
       }
     });
-    data.set(row.geography_code, geoDataMap);
+    data.set(geographyCode ? geographyCode : row.geography_code, geoDataMap);
   });
   return data;
 }

--- a/src/radio.spec.js
+++ b/src/radio.spec.js
@@ -1,10 +1,10 @@
-import Radio from './Radio.svelte'
-import { render } from '@testing-library/svelte'
+import Radio from "./Radio.svelte";
+import { render } from "@testing-library/svelte";
 
-it('it renders', async () => {
+it("it renders", async () => {
   const radioOptionName = "Yes";
   const { container, getByText } = render(Radio, {
-    props: {props: {name: radioOptionName}}
+    props: { props: { name: radioOptionName } },
   });
 
   const radio = container.querySelector("input");

--- a/src/routes/[topicSlug]/[tableSlug]/[categorySlug].svelte
+++ b/src/routes/[topicSlug]/[tableSlug]/[categorySlug].svelte
@@ -228,7 +228,9 @@
   <div class="ons-grid">
     <div class="ons-grid__col ons-col-6@m ">
       <div class="ons-pl-grid-col">
-        <DataComparison difference={eAndWDiff} />
+        {#if geoCode != config.eAndWGeoCode}
+          <DataComparison difference={eAndWDiff} />
+        {/if}
       </div>
     </div>
   </div>

--- a/src/routes/[topicSlug]/[tableSlug]/[categorySlug].svelte
+++ b/src/routes/[topicSlug]/[tableSlug]/[categorySlug].svelte
@@ -27,11 +27,10 @@
     getCategoryBySlug,
     populatesSelectedData,
     selectedData,
-    englandAndWalesData,
     dataByGeography,
     fetchSelectedDataForGeographies,
   } from "../../../model/censusdata/censusdata";
-  import GeodataApiDataService from "../../../model/censusdata/services/geodataApiDataService"
+  import GeodataApiDataService from "../../../model/censusdata/services/geodataApiDataService";
   import LegacyCensusDataService from "../../../model/censusdata/services/legacyCensusDataService";
   import { updateHoveredGeography, updateSelectedGeography, getLadName } from "../../../model/geography/geography";
   import config from "../../../config";
@@ -52,14 +51,12 @@
   let table = null;
   let populateCensusTable = { categories: [] };
   let totalCatCode = "";
-  let eAndWDiff;
+  let eAndWDiff, geoCode;
 
   let locationName = "";
 
   let locationId = $page.query.get("location");
 
-  //if no location in url, set geoCode to England & Wales
-  let geoCode = $page.query.get("location") ? $page.query.get("location") : config.eAndWGeoCode;
   let categoryCodesArr = [];
 
   onMount(async () => {
@@ -105,12 +102,11 @@
       if ($dataByGeography.get(geoCode)) {
         //reassign variable to trigger reactivity
         populateCensusTable = processData($dataByGeography.get(geoCode), populateCensusTable, totalCatCode);
-        eAndWDiff = calculateEnglandWalesDiff(geoCode, totalCatCode, category)
+        eAndWDiff = calculateEnglandWalesDiff(geoCode, totalCatCode, category);
       }
     }
     locationName = getLadName(locationId);
   };
-
 </script>
 
 <svelte:head>
@@ -226,7 +222,7 @@
   <div class="ons-grid">
     <div class="ons-grid__col ons-col-6@m ">
       <div class="ons-pl-grid-col">
-        <DataComparison difference={eAndWDiff}/>
+        <DataComparison difference={eAndWDiff} />
       </div>
     </div>
   </div>

--- a/src/routes/[topicSlug]/[tableSlug]/[categorySlug].svelte
+++ b/src/routes/[topicSlug]/[tableSlug]/[categorySlug].svelte
@@ -15,6 +15,7 @@
   import Feedback from "../../../ui/Feedback.svelte";
   import HeaderWrapper from "../../../ui/HeaderWrapper.svelte";
   import MapLegend from "../../../ui/MapLegend/MapLegend.svelte";
+  import DataComparison from "../../../ui/DataComparison.svelte"
   import metadata from "../../../data/apiMetadata";
   import { filterSelectedTable } from "../../../utils";
 
@@ -209,6 +210,14 @@
   </div>
 
   <CensusTableByLocation {populateCensusTable} {geoCode} {totalCatCode} {categoryCodesArr} />
+
+  <div class="ons-grid">
+    <div class="ons-grid__col ons-col-6@m ">
+      <div class="ons-pl-grid-col">
+        <DataComparison />
+      </div>
+    </div>
+  </div>
 
   <Topic cardTitle="General health with other indicators"
     >Explore correlations between two indicators in <a href="#">advanced mode</a>.

--- a/src/routes/[topicSlug]/[tableSlug]/[categorySlug].svelte
+++ b/src/routes/[topicSlug]/[tableSlug]/[categorySlug].svelte
@@ -15,7 +15,7 @@
   import Feedback from "../../../ui/Feedback.svelte";
   import HeaderWrapper from "../../../ui/HeaderWrapper.svelte";
   import MapLegend from "../../../ui/MapLegend/MapLegend.svelte";
-  import DataComparison from "../../../ui/DataComparison.svelte"
+  import DataComparison from "../../../ui/DataComparison.svelte";
   import metadata from "../../../data/apiMetadata";
   import { filterSelectedTable } from "../../../utils";
 
@@ -27,6 +27,7 @@
     getCategoryBySlug,
     populatesSelectedData,
     selectedData,
+    englandAndWalesData,
   } from "../../../model/censusdata/censusdata";
   import LegacyCensusDataService from "../../../model/censusdata/services/legacyCensusDataService";
   import { updateHoveredGeography, updateSelectedGeography, getLadName } from "../../../model/geography/geography";
@@ -99,6 +100,9 @@
     }
     locationName = getLadName(locationId);
   };
+
+  $: console.log("englandAndWalesData store", $englandAndWalesData.get("K04000001").get(totalCatCode)),
+    console.log($selectedData);
 </script>
 
 <svelte:head>

--- a/src/routes/[topicSlug]/[tableSlug]/[categorySlug].svelte
+++ b/src/routes/[topicSlug]/[tableSlug]/[categorySlug].svelte
@@ -83,8 +83,10 @@
     }
   }
 
+  $: geoCode, fetchSelectedDataset();
+
   // temporary line to load some data
-  $: appIsInitialised, $appIsInitialised && initialisePage();
+  $: appIsInitialised, $appIsInitialised && initialisePage(), fetchSelectedDataset();
 
   const initialisePage = async () => {
     category = getCategoryBySlug(tableSlug, categorySlug);
@@ -98,14 +100,17 @@
         populateCensusTable["categories"].push({ code: category.code, name: category.name });
         categoryCodesArr.push(category.code);
       });
-      await fetchSelectedDataForGeographies(new GeodataApiDataService(), geoCode, categoryCodesArr);
-      if ($dataByGeography.get(geoCode)) {
-        //reassign variable to trigger reactivity
-        populateCensusTable = processData($dataByGeography.get(geoCode), populateCensusTable, totalCatCode);
-        eAndWDiff = calculateEnglandWalesDiff(geoCode, totalCatCode, category);
-      }
     }
     locationName = getLadName(locationId);
+  };
+
+  const fetchSelectedDataset = async () => {
+    await fetchSelectedDataForGeographies(new GeodataApiDataService(), geoCode, categoryCodesArr);
+    if ($dataByGeography.get(geoCode)) {
+      //reassign variable to trigger reactivity
+      populateCensusTable = processData($dataByGeography.get(geoCode), populateCensusTable, totalCatCode);
+      eAndWDiff = calculateEnglandWalesDiff(geoCode, totalCatCode, category);
+    }
   };
 </script>
 

--- a/src/routes/[topicSlug]/[tableSlug]/[categorySlug].svelte
+++ b/src/routes/[topicSlug]/[tableSlug]/[categorySlug].svelte
@@ -39,7 +39,13 @@
   import BoundaryLayer from "../../../ui/map/BoundaryLayer.svelte";
   import DataLayer from "../../../ui/map/DataLayer.svelte";
   import { appIsInitialised } from "../../../model/appstate";
-  import { isNotEmpty, dbColumnToCategoryId, processData, calculateEnglandWalesDiff } from "../../../utils";
+  import {
+    isNotEmpty,
+    dbColumnToCategoryId,
+    processData,
+    calculateEnglandWalesDiff,
+    updateEnglandWalesDiff,
+  } from "../../../utils";
   import { selectedGeography } from "../../../model/geography/geography";
 
   import { goto } from "$app/navigation";
@@ -85,6 +91,7 @@
   }
 
   $: geoCode, fetchSelectedDataset();
+  $: categorySlug, (eAndWDiff = updateEnglandWalesDiff(tableSlug, categorySlug, metadata, geoCode));
 
   // temporary line to load some data
   $: appIsInitialised, $appIsInitialised && initialisePage(), fetchSelectedDataset();

--- a/src/routes/[topicSlug]/[tableSlug]/[categorySlug].svelte
+++ b/src/routes/[topicSlug]/[tableSlug]/[categorySlug].svelte
@@ -79,6 +79,7 @@
       $page.query.set("location", $selectedGeography.lad);
       goto(`?${$page.query.toString()}`);
       locationId = $page.query.get("location");
+      geoCode = locationId;
       locationName = getLadName(locationId);
     }
   }

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -1,20 +1,19 @@
 <script>
   import { initialiseGeography } from "./../model/geography/geography";
   import LegacyGeographyService from "./../model/geography/services/legacyGeographyService";
-  import {initialiseCensusData} from "./../model/censusdata/censusdata"
-  import LegacyCensusDataService from "./../model/censusdata/services/legacyCensusDataService"
+  import { initialiseCensusData } from "./../model/censusdata/censusdata";
+  import LegacyCensusDataService from "./../model/censusdata/services/legacyCensusDataService";
   import { setInitialised } from "./../model/appstate";
-  import {fetchAllDataForGeography} from "./../model/censusdata/censusdata"
-  import GeodataApiDataService from "./../model/censusdata/services/geodataApiDataService"
-  import config from "./../config"
+  import { fetchAllDataForGeography } from "./../model/censusdata/censusdata";
+  import GeodataApiDataService from "./../model/censusdata/services/geodataApiDataService";
+  import config from "./../config";
 
   initialiseGeography(new LegacyGeographyService()).then(() => {
     initialiseCensusData(new LegacyCensusDataService()).then(() => setInitialised());
   });
 
   //fetch and cache all England & Wales data on initialise
-  fetchAllDataForGeography(new GeodataApiDataService(), config.eAndWGeoCode)
-
+  fetchAllDataForGeography(new GeodataApiDataService(), config.eAndWGeoCode);
 </script>
 
 <slot />

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -6,13 +6,14 @@
   import { setInitialised } from "./../model/appstate";
   import {fetchAllDataForGeography} from "./../model/censusdata/censusdata"
   import GeodataApiDataService from "./../model/censusdata/services/geodataApiDataService"
+  import config from "./../config"
 
   initialiseGeography(new LegacyGeographyService()).then(() => {
     initialiseCensusData(new LegacyCensusDataService()).then(() => setInitialised());
   });
 
   //fetch and cache all England & Wales data on initialise
-  fetchAllDataForGeography(new GeodataApiDataService(), "K04000001")
+  fetchAllDataForGeography(new GeodataApiDataService(), config.eAndWGeoCode)
 
 </script>
 

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -1,13 +1,19 @@
 <script>
   import { initialiseGeography } from "./../model/geography/geography";
   import LegacyGeographyService from "./../model/geography/services/legacyGeographyService";
-  import { initialiseCensusData } from "./../model/censusdata/censusdata";
-  import LegacyCensusDataService from "./../model/censusdata/services/legacyCensusDataService";
+  import {initialiseCensusData} from "./../model/censusdata/censusdata"
+  import LegacyCensusDataService from "./../model/censusdata/services/legacyCensusDataService"
   import { setInitialised } from "./../model/appstate";
+  import {fetchAllDataForGeography} from "./../model/censusdata/censusdata"
+  import GeodataApiDataService from "./../model/censusdata/services/geodataApiDataService"
 
   initialiseGeography(new LegacyGeographyService()).then(() => {
     initialiseCensusData(new LegacyCensusDataService()).then(() => setInitialised());
   });
+
+  //fetch and cache all England & Wales data on initialise
+  fetchAllDataForGeography(new GeodataApiDataService(), "K04000001")
+
 </script>
 
 <slot />

--- a/src/routes/components.svelte
+++ b/src/routes/components.svelte
@@ -23,6 +23,7 @@
   import ONSLinkedinIcon from "./../ui/ons/svg/ONSLinkedinIcon.svelte";
   import ONSEmailIcon from "./../ui/ons/svg/ONSEmailIcon.svelte";
   import config from "../config";
+  import DataComparison from "./../ui/DataComparison.svelte";
 
   let topicList1 = [
     {
@@ -194,9 +195,9 @@
   <DesignSystemPanel title="Design system code block">
     <DesignSystemCode code={`<DesignSystemCode code={\`<App />\`} />`} />
   </DesignSystemPanel>
-  <DesignSystemPanel title="Display census data by location" code={`<CensusTableByLocation />`}>
+  <!-- <DesignSystemPanel title="Display census data by location" code={`<CensusTableByLocation />`}>
     <CensusTableByLocation />
-  </DesignSystemPanel>
+  </DesignSystemPanel> -->
 
   <DesignSystemPanel
     title="Share"
@@ -213,5 +214,9 @@
       <ONSShareItem linkedin shareText="Linkedin"><ONSLinkedinIcon /></ONSShareItem>
       <ONSShareItem email shareText="Email"><ONSEmailIcon /></ONSShareItem>
     </ONSShare>
+  </DesignSystemPanel>
+
+  <DesignSystemPanel>
+    <DataComparison />
   </DesignSystemPanel>
 </BasePage>

--- a/src/ui/CensusTableByLocation.svelte
+++ b/src/ui/CensusTableByLocation.svelte
@@ -1,22 +1,7 @@
 <script>
   import { selectedData } from "../model/censusdata/censusdata";
-  import { dataByGeography, newDataByGeography } from "../model/censusdata/censusdata";
-  import { processData } from "../utils";
-  import { fetchSelectedDataForGeographies } from "../model/censusdata/censusdata";
-  import GeodataApiDataService from "../model/censusdata/services/geodataApiDataService";
-  export let geoCode, populateCensusTable, totalCatCode, categoryCodesArr;
+  export let populateCensusTable;
 
-  $: {
-    $newDataByGeography;
-    geoCode;
-    if (categoryCodesArr.length > 0) {
-      fetchSelectedDataForGeographies(new GeodataApiDataService(), geoCode, categoryCodesArr);
-      if ($dataByGeography.get(geoCode)) {
-        //reassign variable to trigger reactivity
-        populateCensusTable = processData($dataByGeography.get(geoCode), populateCensusTable, totalCatCode);
-      }
-    }
-  }
 </script>
 
 {#if $selectedData}

--- a/src/ui/CensusTableByLocation.svelte
+++ b/src/ui/CensusTableByLocation.svelte
@@ -1,7 +1,6 @@
 <script>
   import { selectedData } from "../model/censusdata/censusdata";
   export let populateCensusTable;
-
 </script>
 
 {#if $selectedData}

--- a/src/ui/DataComparison.svelte
+++ b/src/ui/DataComparison.svelte
@@ -23,7 +23,7 @@
     };
   }
 
-  const comparisonObj = populateComparisonString(difference, comparator);
+  $: comparisonObj = populateComparisonString(difference, comparator);
 </script>
 
 <div class="data-comparison-container">
@@ -36,39 +36,51 @@
   >
     <div class={difference > 0 ? "text-white" : "text-black"}>
       <div class="ons-grid--flex ons-grid--align-mid">
-      <div class="data-comparison-icon">
-        {#if difference == 0}
-        <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" id="Capa_1" x="0px" y="0px" width="22.354px" height="22.354px" viewBox="0 0 22.354 22.354" style="enable-background:new 0 0 22.354 22.354;" xml:space="preserve">
-          <g>
-            <g>
-              <rect y="3.78" width="22.354" height="5.132"/>
-              <rect y="13.441" width="22.354" height="5.133"/>
-            </g>
-          </g>
-          </svg>
-        {:else}
-        <svg
-          class={difference < 0 ? "upside-down-icon" : ""}
-          fill={difference < 0 ? "#222222": "#ffffff"}
-          xmlns="http://www.w3.org/2000/svg"
-          width="26"
-          height="26"
-          viewBox="0 0 24 24"
-        >
-          <path d="M24 22h-24l12-20z" />
-        </svg>
+        <div class="data-comparison-icon">
+          {#if difference == 0}
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              xmlns:xlink="http://www.w3.org/1999/xlink"
+              version="1.1"
+              id="Capa_1"
+              x="0px"
+              y="0px"
+              width="22.354px"
+              height="22.354px"
+              viewBox="0 0 22.354 22.354"
+              style="enable-background:new 0 0 22.354 22.354;"
+              xml:space="preserve"
+            >
+              <g>
+                <g>
+                  <rect y="3.78" width="22.354" height="5.132" />
+                  <rect y="13.441" width="22.354" height="5.133" />
+                </g>
+              </g>
+            </svg>
+          {:else}
+            <svg
+              class={difference < 0 ? "upside-down-icon" : ""}
+              fill={difference < 0 ? "#222222" : "#ffffff"}
+              xmlns="http://www.w3.org/2000/svg"
+              width="26"
+              height="26"
+              viewBox="0 0 24 24"
+            >
+              <path d="M24 22h-24l12-20z" />
+            </svg>
+          {/if}
+        </div>
+        {#if comparisonObj.percentage != null}
+          <p class="ons-u-fs-xl data-comparison-graphic-text">{comparisonObj.percentage}</p>
         {/if}
-      </div>
-      {#if comparisonObj.percentage != null}
-      <p class="ons-u-fs-xl data-comparison-graphic-text">{comparisonObj.percentage}</p>
-      {/if}
-      <p
-        class="ons-u-fs-m data-comparison-graphic-text
+        <p
+          class="ons-u-fs-m data-comparison-graphic-text
             data-comparison-graphic-text--small"
-      >
-        {comparisonObj.comparative}
-      </p>
-    </div>
+        >
+          {comparisonObj.comparative}
+        </p>
+      </div>
     </div>
   </div>
 

--- a/src/ui/DataComparison.svelte
+++ b/src/ui/DataComparison.svelte
@@ -1,44 +1,79 @@
 <script>
-  export let difference = 0.5;
-  export let comparisonGeography = "England and Wales";
+  export let difference = 0;
+  export let comparator = "England and Wales";
 
-  function populateComparisonString(difference) {
+  function populateComparisonString(difference, comparator) {
     if (difference > 0) {
       return {
         percentage: difference.toString(),
-        comparative: "% higher"
+        comparative: "% higher",
+        comparison: `Than in ${comparator}`,
       };
     } else if (difference < 0) {
       return {
         percentage: Math.abs(difference).toString(),
-        comparative: "% lower"
-      };;
+        comparative: "% lower",
+        comparison: `Than in ${comparator}`,
+      };
     }
     return {
       percentage: null,
       comparative: "The same as",
+      comparison: `The value is the same as in ${comparator}`,
     };
   }
 
-  const comparisonObj = populateComparisonString(difference);
+  const comparisonObj = populateComparisonString(difference, comparator);
 </script>
 
 <div class="data-comparison-container">
-  <div class="data-display-panel">
+  <div
+    class={difference > 0
+      ? "data-display-panel-blue"
+      : difference < 0
+      ? "data-display-panel-green"
+      : "data-display-panel-teal"}
+  >
+    <div class={difference > 0 ? "text-white" : "text-black"}>
       <div class="ons-grid--flex ons-grid--align-mid">
-        <div class="data-comparison-icon">
-          <svg fill="#ffffff" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-            <path d="M24 22h-24l12-20z" />
+      <div class="data-comparison-icon">
+        {#if difference == 0}
+        <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" id="Capa_1" x="0px" y="0px" width="22.354px" height="22.354px" viewBox="0 0 22.354 22.354" style="enable-background:new 0 0 22.354 22.354;" xml:space="preserve">
+          <g>
+            <g>
+              <rect y="3.78" width="22.354" height="5.132"/>
+              <rect y="13.441" width="22.354" height="5.133"/>
+            </g>
+          </g>
           </svg>
-        </div>
-
-            <p class="ons-u-fs-xl data-comparison-graphic-text">{comparisonObj.percentage}</p><p class="ons-u-fs-m data-comparison-graphic-text
-            data-comparison-graphic-text--small">{comparisonObj.comparative}</p>
+        {:else}
+        <svg
+          class={difference < 0 ? "upside-down-icon" : ""}
+          fill={difference < 0 ? "#222222": "#ffffff"}
+          xmlns="http://www.w3.org/2000/svg"
+          width="26"
+          height="26"
+          viewBox="0 0 24 24"
+        >
+          <path d="M24 22h-24l12-20z" />
+        </svg>
+        {/if}
       </div>
+      {#if comparisonObj.percentage != null}
+      <p class="ons-u-fs-xl data-comparison-graphic-text">{comparisonObj.percentage}</p>
+      {/if}
+      <p
+        class="ons-u-fs-m data-comparison-graphic-text
+            data-comparison-graphic-text--small"
+      >
+        {comparisonObj.comparative}
+      </p>
+    </div>
+    </div>
   </div>
 
   <div class="data-comparison-text">
-    <p>Than in {comparisonGeography}</p>
+    <p>{comparisonObj.comparison}</p>
   </div>
 </div>
 
@@ -49,7 +84,10 @@
     height: 100%;
   }
 
-  .data-display-panel,
+  .data-display-panel-blue,
+  .data-display-panel-green,
+  .data-display-panel-grey,
+  .data-display-panel-teal,
   .data-comparison-text {
     position: relative;
     width: 100%;
@@ -57,41 +95,64 @@
     padding: 0.4rem 1rem;
   }
 
-  .data-display-panel {
-    background-color: $color-night-blue;
+  .data-display-panel-blue {
+    background-color: #005583;
+  }
+
+  .data-display-panel-green {
+    background-color: #d5f690;
+  }
+
+  .data-display-panel-grey {
+    background-color: $color-grey-35;
+  }
+
+  .data-display-panel-teal {
+    background-color: #2e9daa;
   }
 
   .data-comparison-text {
     background-color: $color-white;
   }
 
-  .data-comparison-icon, .data-comparison-graphic-text {
+  .data-comparison-icon,
+  .data-comparison-graphic-text {
     display: inline-block;
   }
 
   .data-comparison-icon {
-    margin: 0 .7rem .35rem 0;
+    margin: 0 0.7rem 0.35rem 0;
     display: flex;
     flex-direction: column;
     justify-content: flex-end;
   }
 
-  .data-comparison-graphic-text {
-      color: $color-white;
-      font-weight: bold;
-      margin: 0;
+  .upside-down-icon {
+    transform: rotate(180deg);
+  }
 
-      &--small {
-        display: flex;
-        flex-direction: column;
-        justify-content: flex-end;
-        margin: 0 0 .1rem 0;
-      }
+  .data-comparison-graphic-text {
+    margin: 0;
+
+    &--small {
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-end;
+      margin: 0 0 0.1rem 0;
+    }
   }
 
   @media only screen and (max-width: map-get($grid-bp, m)) {
     .data-comparison-graphic-text--small {
-      margin: 0 0 .15rem 0;
+      margin: 0 0 0.15rem 0;
     }
+  }
+
+  .text-white {
+    color: $color-white;
+  }
+
+  .text-black {
+    color: $color-black;
   }
 </style>

--- a/src/ui/DataComparison.svelte
+++ b/src/ui/DataComparison.svelte
@@ -1,13 +1,27 @@
 <script>
-  export let difference;
+  export let difference = 0.5;
   export let comparisonGeography = "England and Wales";
+
+  function populateComparisonString(difference) {
+    if (difference > 0) {
+      return `${difference.toString()}% higher`;
+    } else if (difference < 0) {
+      return `${difference.toString()}% lower`;
+    }
+    return "The same as";
+  }
+
+  const comparisonString = populateComparisonString(difference);
 </script>
 
 <div class="data-comparison-container">
   <div class="data-display">
-    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-      <path d="M24 22h-24l12-20z" />
-    </svg>
+    <span>
+      <svg class="data-comparison-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+        <path d="M24 22h-24l12-20z" />
+      </svg>
+      <p class="data-comparison-string">{comparisonString}</p>
+    </span>
   </div>
 
   <div class="data-comparison-text">
@@ -30,10 +44,14 @@
   }
 
   .data-display {
-    background-color: $color-night-blue;
+    background-color: $color-ocean-blue;
   }
 
   .data-comparison-text {
     background-color: $color-white;
+  }
+
+  .data-comparison-icon, .data-comparison-string {
+    display: inline-block;
   }
 </style>

--- a/src/ui/DataComparison.svelte
+++ b/src/ui/DataComparison.svelte
@@ -1,0 +1,39 @@
+<script>
+  export let difference;
+  export let comparisonGeography = "England and Wales";
+</script>
+
+<div class="data-comparison-container">
+  <div class="data-display">
+    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+      <path d="M24 22h-24l12-20z" />
+    </svg>
+  </div>
+
+  <div class="data-comparison-text">
+    <p>Than in {comparisonGeography}</p>
+  </div>
+</div>
+
+<style lang="scss">
+  @import "../node_modules/@ons/design-system/scss/vars/_index.scss";
+
+  .data-comparison-container {
+    height: 100%;
+  }
+
+  .data-display,
+  .data-comparison-text {
+    position: relative;
+    width: 100%;
+    height: 50%;
+  }
+
+  .data-display {
+    background-color: $color-night-blue;
+  }
+
+  .data-comparison-text {
+    background-color: $color-white;
+  }
+</style>

--- a/src/ui/DataComparison.svelte
+++ b/src/ui/DataComparison.svelte
@@ -15,13 +15,15 @@
 </script>
 
 <div class="data-comparison-container">
-  <div class="data-display">
-    <span>
-      <svg class="data-comparison-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-        <path d="M24 22h-24l12-20z" />
-      </svg>
-      <p class="data-comparison-string">{comparisonString}</p>
-    </span>
+  <div class="data-display-panel">
+      <div class="ons-grid--flex ons-grid--between ons-grid--vertical-center">
+        <span>
+            <svg fill="#ffffff" class="data-comparison-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+              <path d="M24 22h-24l12-20z" />
+            </svg>
+            <p class="data-comparison-graphic-text">{comparisonString}</p>
+          </span>
+      </div>
   </div>
 
   <div class="data-comparison-text">
@@ -36,22 +38,27 @@
     height: 100%;
   }
 
-  .data-display,
+  .data-display-panel,
   .data-comparison-text {
     position: relative;
     width: 100%;
     height: 50%;
   }
 
-  .data-display {
-    background-color: $color-ocean-blue;
+  .data-display-panel {
+    background-color: $color-night-blue;
   }
 
   .data-comparison-text {
     background-color: $color-white;
   }
 
-  .data-comparison-icon, .data-comparison-string {
+  .data-comparison-icon, .data-comparison-graphic-text {
     display: inline-block;
+  }
+
+  .data-comparison-graphic-text {
+      color: $color-white;
+      font-weight: bold;
   }
 </style>

--- a/src/ui/DataComparison.svelte
+++ b/src/ui/DataComparison.svelte
@@ -4,25 +4,36 @@
 
   function populateComparisonString(difference) {
     if (difference > 0) {
-      return `${difference.toString()}% higher`;
+      return {
+        percentage: difference.toString(),
+        comparative: "% higher"
+      };
     } else if (difference < 0) {
-      return `${difference.toString()}% lower`;
+      return {
+        percentage: Math.abs(difference).toString(),
+        comparative: "% lower"
+      };;
     }
-    return "The same as";
+    return {
+      percentage: null,
+      comparative: "The same as",
+    };
   }
 
-  const comparisonString = populateComparisonString(difference);
+  const comparisonObj = populateComparisonString(difference);
 </script>
 
 <div class="data-comparison-container">
   <div class="data-display-panel">
-      <div class="ons-grid--flex ons-grid--between ons-grid--vertical-center">
-        <span>
-            <svg fill="#ffffff" class="data-comparison-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-              <path d="M24 22h-24l12-20z" />
-            </svg>
-            <p class="data-comparison-graphic-text">{comparisonString}</p>
-          </span>
+      <div class="ons-grid--flex ons-grid--align-mid">
+        <div class="data-comparison-icon">
+          <svg fill="#ffffff" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+            <path d="M24 22h-24l12-20z" />
+          </svg>
+        </div>
+
+            <p class="ons-u-fs-xl data-comparison-graphic-text">{comparisonObj.percentage}</p><p class="ons-u-fs-m data-comparison-graphic-text
+            data-comparison-graphic-text--small">{comparisonObj.comparative}</p>
       </div>
   </div>
 
@@ -43,6 +54,7 @@
     position: relative;
     width: 100%;
     height: 50%;
+    padding: 0.4rem 1rem;
   }
 
   .data-display-panel {
@@ -57,8 +69,29 @@
     display: inline-block;
   }
 
+  .data-comparison-icon {
+    margin: 0 .7rem .35rem 0;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+  }
+
   .data-comparison-graphic-text {
       color: $color-white;
       font-weight: bold;
+      margin: 0;
+
+      &--small {
+        display: flex;
+        flex-direction: column;
+        justify-content: flex-end;
+        margin: 0 0 .1rem 0;
+      }
+  }
+
+  @media only screen and (max-width: map-get($grid-bp, m)) {
+    .data-comparison-graphic-text--small {
+      margin: 0 0 .15rem 0;
+    }
   }
 </style>

--- a/src/ui/DataComparison.svelte
+++ b/src/ui/DataComparison.svelte
@@ -72,7 +72,9 @@
           {/if}
         </div>
         {#if comparisonObj.percentage != null}
-          <p class="ons-u-fs-l data-comparison-graphic-text data-comparison-graphic-text--large">{comparisonObj.percentage}</p>
+          <p class="ons-u-fs-l data-comparison-graphic-text data-comparison-graphic-text--large">
+            {comparisonObj.percentage}
+          </p>
         {/if}
         <p
           class="ons-u-fs-m data-comparison-graphic-text
@@ -155,7 +157,8 @@
   }
 
   @media only screen and (max-width: map-get($grid-bp, m)) {
-    .data-comparison-graphic-text--small, .data-comparison-graphic-text--large {
+    .data-comparison-graphic-text--small,
+    .data-comparison-graphic-text--large {
       margin: 0 0 0.15rem 0;
     }
   }

--- a/src/ui/DataComparison.svelte
+++ b/src/ui/DataComparison.svelte
@@ -72,7 +72,7 @@
           {/if}
         </div>
         {#if comparisonObj.percentage != null}
-          <p class="ons-u-fs-xl data-comparison-graphic-text">{comparisonObj.percentage}</p>
+          <p class="ons-u-fs-l data-comparison-graphic-text data-comparison-graphic-text--large">{comparisonObj.percentage}</p>
         {/if}
         <p
           class="ons-u-fs-m data-comparison-graphic-text
@@ -155,7 +155,7 @@
   }
 
   @media only screen and (max-width: map-get($grid-bp, m)) {
-    .data-comparison-graphic-text--small {
+    .data-comparison-graphic-text--small, .data-comparison-graphic-text--large {
       margin: 0 0 0.15rem 0;
     }
   }

--- a/src/ui/feedback.spec.js
+++ b/src/ui/feedback.spec.js
@@ -1,23 +1,23 @@
-import Feedback from './Feedback.svelte'
-import { render, fireEvent } from '@testing-library/svelte'
+import Feedback from "./Feedback.svelte";
+import { render, fireEvent } from "@testing-library/svelte";
 
-const BaseLinkURL = 'http://localhost';
+const BaseLinkURL = "http://localhost";
 
-it('it renders', async () => {
+it("it renders", async () => {
   const { getByText } = render(Feedback);
 
-  const heading = getByText('Is this page useful?');
-  const yesLink = getByText('Yes');
-  const noLink = getByText('No');
+  const heading = getByText("Is this page useful?");
+  const yesLink = getByText("Yes");
+  const noLink = getByText("No");
   const notFoundLink = getByText("Can't find what you're looking for?");
-  
+
   expect(heading).not.toBe(null);
   expect(yesLink).not.toBe(null);
-  expect(yesLink.href).toBe(BaseLinkURL + '/feedback/thanks');
+  expect(yesLink.href).toBe(BaseLinkURL + "/feedback/thanks");
   expect(noLink).not.toBe(null);
-  expect(noLink.href).toBe(BaseLinkURL + '/feedback?service=cmd');
+  expect(noLink.href).toBe(BaseLinkURL + "/feedback?service=cmd");
   expect(notFoundLink).not.toBe(null);
-  expect(notFoundLink.href).toBe(BaseLinkURL + '/feedback?service=cmd');
-  
+  expect(notFoundLink.href).toBe(BaseLinkURL + "/feedback?service=cmd");
+
   await fireEvent.click(yesLink);
 });

--- a/src/ui/select.spec.js
+++ b/src/ui/select.spec.js
@@ -1,22 +1,22 @@
-import Select from './Select.svelte'
+import Select from "./Select.svelte";
 import { fireEvent, render } from "@testing-library/svelte";
 
-describe('Select', () => {
-  test('it renders', async () => {
+describe("Select", () => {
+  test("it renders", async () => {
     const { container } = render(Select);
 
-    const selectElement = container.querySelector('#select');
-    const toggleElement = container.querySelector('#toggle');
-    const dropdownElement = container.querySelector('#dropdown');
+    const selectElement = container.querySelector("#select");
+    const toggleElement = container.querySelector("#toggle");
+    const dropdownElement = container.querySelector("#dropdown");
 
     expect(selectElement).not.toBeNull();
     expect(toggleElement).not.toBeNull();
     expect(dropdownElement).toBeNull();
-  })
+  });
 
-  test('displays the placeholder when not selected', async () => {
+  test("displays the placeholder when not selected", async () => {
     const { getByText } = render(Select, {
-      selected: false
+      selected: false,
     });
 
     const placeholder = getByText("Select an option");
@@ -24,59 +24,55 @@ describe('Select', () => {
     expect(placeholder).not.toBeNull();
   });
 
-  test('displays custom placeholder text if it is provided', async () => {
+  test("displays custom placeholder text if it is provided", async () => {
     const testPlaceholder = "a test placeholder";
     const { getByText } = render(Select, {
       selected: false,
-      placeholder: testPlaceholder
+      placeholder: testPlaceholder,
     });
 
     const customPlaceholder = getByText(testPlaceholder);
 
     expect(customPlaceholder).not.toBeNull();
   });
-  
-  test('displays dropdown when the select clicked',  async () => {
-    const { container } = render(Select, {options: []});
 
-    const toggleElement = container.querySelector('#toggle');
-    let dropdownElement = container.querySelector('#dropdown');
+  test("displays dropdown when the select clicked", async () => {
+    const { container } = render(Select, { options: [] });
+
+    const toggleElement = container.querySelector("#toggle");
+    let dropdownElement = container.querySelector("#dropdown");
 
     expect(toggleElement).not.toBeNull();
     expect(dropdownElement).toBeNull();
-    
+
     await fireEvent.click(toggleElement);
 
-    dropdownElement = container.querySelector('#dropdown');
+    dropdownElement = container.querySelector("#dropdown");
 
     expect(dropdownElement).not.toBeNull();
   });
 
-  test('displays "No Results" in dropdown if no options provided',  async () => {
-    const { container, getByText } = render(Select, {options: []});
+  test('displays "No Results" in dropdown if no options provided', async () => {
+    const { container, getByText } = render(Select, { options: [] });
 
-    const toggleElement = container.querySelector('#toggle');
+    const toggleElement = container.querySelector("#toggle");
     expect(toggleElement).not.toBeNull();
 
     await fireEvent.click(toggleElement);
 
-    const noResultsItem = getByText('No results');
+    const noResultsItem = getByText("No results");
 
     expect(noResultsItem).not.toBeNull();
   });
 
-  test('displays each option provided in dropdown if no filter applied',  async () => {
-    const area1Name = 'Area 1';
-    const area2Name = 'Area 2';
-    const { container, getByText } = render(Select, 
-      {
-        options: [
-          {AREANM: area1Name},
-          {AREANM: area2Name}
-        ]
-      });
+  test("displays each option provided in dropdown if no filter applied", async () => {
+    const area1Name = "Area 1";
+    const area2Name = "Area 2";
+    const { container, getByText } = render(Select, {
+      options: [{ AREANM: area1Name }, { AREANM: area2Name }],
+    });
 
-    const toggleElement = container.querySelector('#toggle');
+    const toggleElement = container.querySelector("#toggle");
     expect(toggleElement).not.toBeNull();
 
     await fireEvent.click(toggleElement);
@@ -87,4 +83,4 @@ describe('Select', () => {
     expect(area1Item).not.toBeNull();
     expect(area2Item).not.toBeNull();
   });
-})
+});

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,8 +1,8 @@
 import { csvParse, autoType } from "d3-dsv";
 import { get } from "svelte/store";
 import { ckmeans } from "simple-statistics";
-import {englandAndWalesData, dataByGeography} from "./model/censusdata/censusdata"
-import config from "./config"
+import { englandAndWalesData, dataByGeography } from "./model/censusdata/censusdata";
+import config from "./config";
 
 export async function getLsoaData(url) {
   let response = await fetch(url);
@@ -262,11 +262,11 @@ export function filterSelectedTable(metadata, category) {
   return selectedTable;
 }
 
-export function calculateEnglandWalesDiff(geoCode, totalCatCode, category){
-  const eAndWTotal = get(englandAndWalesData).get(config.eAndWGeoCode).get(totalCatCode)
-  const eAndWVal = get(englandAndWalesData).get(config.eAndWGeoCode).get(category.code)
-  const localTotal = get(dataByGeography).get(geoCode).get(totalCatCode)
-  const localVal = get(dataByGeography).get(geoCode).get(category.code)
-  const percentageDiff = (eAndWVal / eAndWTotal)*100 - (localVal / localTotal)*100
-  return Math.round(percentageDiff * 10) / 10
+export function calculateEnglandWalesDiff(geoCode, totalCatCode, category) {
+  const eAndWTotal = get(englandAndWalesData).get(config.eAndWGeoCode).get(totalCatCode);
+  const eAndWVal = get(englandAndWalesData).get(config.eAndWGeoCode).get(category.code);
+  const localTotal = get(dataByGeography).get(geoCode).get(totalCatCode);
+  const localVal = get(dataByGeography).get(geoCode).get(category.code);
+  const percentageDiff = (localVal / localTotal) * 100 - (eAndWVal / eAndWTotal) * 100;
+  return Math.round(percentageDiff * 10) / 10;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,8 @@
-import { feature } from "topojson-client";
 import { csvParse, autoType } from "d3-dsv";
 import { get } from "svelte/store";
 import { ckmeans } from "simple-statistics";
+import {englandAndWalesData, dataByGeography} from "./model/censusdata/censusdata"
+import config from "./config"
 
 export async function getLsoaData(url) {
   let response = await fetch(url);
@@ -259,4 +260,13 @@ export function filterSelectedTable(metadata, category) {
     });
   });
   return selectedTable;
+}
+
+export function calculateEnglandWalesDiff(geoCode, totalCatCode, category){
+  const eAndWTotal = get(englandAndWalesData).get(config.eAndWGeoCode).get(totalCatCode)
+  const eAndWVal = get(englandAndWalesData).get(config.eAndWGeoCode).get(category.code)
+  const localTotal = get(dataByGeography).get(geoCode).get(totalCatCode)
+  const localVal = get(dataByGeography).get(geoCode).get(category.code)
+  const percentageDiff = (eAndWVal / eAndWTotal)*100 - (localVal / localTotal)*100
+  return Math.round(percentageDiff * 10) / 10
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,7 @@
 import { csvParse, autoType } from "d3-dsv";
 import { get } from "svelte/store";
 import { ckmeans } from "simple-statistics";
-import { englandAndWalesData, dataByGeography } from "./model/censusdata/censusdata";
+import { englandAndWalesData, dataByGeography, getCategoryBySlug } from "./model/censusdata/censusdata";
 import config from "./config";
 
 export async function getLsoaData(url) {
@@ -270,3 +270,12 @@ export function calculateEnglandWalesDiff(geoCode, totalCatCode, category) {
   const percentageDiff = (localVal / localTotal) * 100 - (eAndWVal / eAndWTotal) * 100;
   return Math.round(percentageDiff * 10) / 10;
 }
+
+export const updateEnglandWalesDiff = (tableSlug, categorySlug, metadata, geoCode) => {
+  let category = getCategoryBySlug(tableSlug, categorySlug);
+  let table = category ? filterSelectedTable(metadata, category) : null;
+  if (get(dataByGeography).get(geoCode)) {
+    let eAndWDiff = calculateEnglandWalesDiff(geoCode, table.total.code, category);
+    return eAndWDiff;
+  }
+};


### PR DESCRIPTION
New component for data comparison with England & Wales, set up to be flexible for the needs of the other comparisons in the designs.
![Screenshot 2022-01-25 at 09 16 07](https://user-images.githubusercontent.com/70749355/150947640-b792152f-9ded-4b98-982a-6bee63194f1a.png)

We have also changed the data handing and cached data structure slightly to serve the component and for improved design and consistency.  Now:
- there is a separate englandAndWalesData store
- all GeodataAPIDataService requests return data in the same 2D Map format
- the fetch request that was being made in the CensusTableByLocation component has now been moved up to the [categorySlug] page. Although not strictly necessary because of the behaviour of stores in Svelte, this is hopefully more intuitive as the page is the parent of CensusTableByLocation and DataComparison, both of which use this data.

The England & Wales geocode has also been moved to config.