### PR TITLE
Fix: Fixed categories repeating

### DIFF
--- a/src/ui/CategorySelector/CategorySelector.svelte
+++ b/src/ui/CategorySelector/CategorySelector.svelte
@@ -6,11 +6,14 @@
   export let selectedCategory = "";
 
   $: locationQueryParam = locationId ? `?location=${locationId}` : "";
-  let leftIndex, rightIndex, selectedCatIndex;
+  let leftIndex, rightIndex, selectedCatIndex, isMultiSelect, isInitialCat;
 
   const findSelectedCatIndex = (category) => category.code === selectedCategory;
   selectedCatIndex = categories.findIndex(findSelectedCatIndex);
 
+  /* isMultiSelect, flag is used to fix a ui issue with an array less than or equal to two showing the same category for both the previous and next links */
+  isMultiSelect = categories.length > 2;
+  $: isInitialCat = selectedCatIndex === 0;
   if (categories && selectedCatIndex === categories.length - 1) {
     rightIndex = 0;
     leftIndex = selectedCatIndex - 1;
@@ -57,23 +60,32 @@
     </div>
   </div>
   <div class="category-selector__links">
-    <p class="category-selector__link category-selector__link--previous">
-      <a
-        href="/{topicSlug}/{tableSlug}/{categories[selectedCatIndex].slug}{locationQueryParam}"
-        on:click={clickLeft}
-      >
-        {categories[leftIndex].name}
-      </a>
-    </p>
+    {#if isMultiSelect}
+      <p class="category-selector__link category-selector__link--previous">
+        <a href="/{topicSlug}/{tableSlug}/{categories[selectedCatIndex].slug}{locationQueryParam}" on:click={clickLeft}>
+          {categories[leftIndex].name}
+        </a>
+      </p>
 
-    <p class="category-selector__link category-selector__link--next">
-      <a
-        href="/{topicSlug}/{tableSlug}/{categories[selectedCatIndex].slug}{locationQueryParam}"
-        on:click={clickRight}
-      >
-        {categories[rightIndex].name}
-      </a>
-    </p>
+      <p class="category-selector__link category-selector__link--next">
+        <a
+          href="/{topicSlug}/{tableSlug}/{categories[selectedCatIndex].slug}{locationQueryParam}"
+          on:click={clickRight}
+        >
+          {categories[rightIndex].name}
+        </a>
+      </p>
+    {:else}
+      {#if isInitialCat} <p class="category-selector__link" />{/if}
+      <p class={`category-selector__link category-selector__link--${isInitialCat ? "next" : "single-previous"}`}>
+        <a
+          href="/{topicSlug}/{tableSlug}/{categories[selectedCatIndex].slug}{locationQueryParam}"
+          on:click={() => (isInitialCat ? clickRight() : clickLeft())}
+        >
+          {categories[isInitialCat ? rightIndex : leftIndex].name}
+        </a>
+      </p>
+    {/if}
   </div>
 </div>
 
@@ -136,6 +148,10 @@
       }
       &--previous {
         background: url(./chevron--left.svg) no-repeat 0 50%;
+      }
+      &--single-previous {
+        border-right: 1px solid rgba($color-white, 0.5);
+        background: url(./chevron--left.svg) no-repeat 0% 50%;
       }
       &--next {
         text-align: right;

--- a/src/ui/CategorySelector/CategorySelector.svelte
+++ b/src/ui/CategorySelector/CategorySelector.svelte
@@ -77,7 +77,7 @@
       </p>
     {:else}
       {#if isInitialCat} <p class="category-selector__link" />{/if}
-      <p class={`category-selector__link category-selector__link--${isInitialCat ? "next" : "single-previous"}`}>
+      <p class={`category-selector__link category-selector__link--${isInitialCat ? "next" : "previous"}`}>
         <a
           href="/{topicSlug}/{tableSlug}/{categories[selectedCatIndex].slug}{locationQueryParam}"
           on:click={() => (isInitialCat ? clickRight() : clickLeft())}
@@ -85,6 +85,7 @@
           {categories[isInitialCat ? rightIndex : leftIndex].name}
         </a>
       </p>
+      {#if !isInitialCat} <p class="category-selector__link--divider" />{/if}
     {/if}
   </div>
 </div>
@@ -149,9 +150,8 @@
       &--previous {
         background: url(./chevron--left.svg) no-repeat 0 50%;
       }
-      &--single-previous {
+      &--divider {
         border-right: 1px solid rgba($color-white, 0.5);
-        background: url(./chevron--left.svg) no-repeat 0% 50%;
       }
       &--next {
         text-align: right;


### PR DESCRIPTION
…for both previous and next links if categories have a length of two or less.

Ticket: https://trello.com/c/Ufwawk06/267-fix-repetition-on-carousel-when-theres-only-two-options

Screenshots of functionality working locally.

<img width="490" alt="Option one of two" src="https://user-images.githubusercontent.com/60074877/153198635-026b5cd5-f28f-4060-ab16-935cad87d7ec.png">
<img width="246" alt="Option two of two" src="https://user-images.githubusercontent.com/60074877/153198638-3c3f2111-3f75-4f91-af97-d163ead2a85d.png">

