### PR TITLE
fixes the no source with ID map error - ticket#269

### DIFF
--- a/src/ui/map/TileSet.svelte
+++ b/src/ui/map/TileSet.svelte
@@ -29,7 +29,7 @@
 
   // watches for isSourceLoaded method on map
   function isSourceLoaded() {
-    if (map.isSourceLoaded(id)) {
+    if (map.getSource(id)) {
       loaded = true;
     } else {
       setTimeout(() => {

--- a/src/ui/map/TileSet.svelte
+++ b/src/ui/map/TileSet.svelte
@@ -29,7 +29,7 @@
 
   // watches for isSourceLoaded method on map
   function isSourceLoaded() {
-    if (map.getSource(id)) {
+    if (map.getSource(id) && map.isSourceLoaded(id)) {
       loaded = true;
     } else {
       setTimeout(() => {


### PR DESCRIPTION
**What**

![Screenshot 2022-02-03 at 13 57 22](https://user-images.githubusercontent.com/70764326/154074758-5124279d-8d94-449e-9b62-082d1d92571b.png)

Because the mapbox [ isSourceLoaded method returns error instead of false](https://github.com/mapbox/mapbox-gl-js/issues/9430) I believe that this issue can be fixed by only swapping the `isSourceLoaded` check with `getSource` inside of the custom `isSourceLoaded` function.