### PR TITLE
Fix: Incorrect use of ARIA.

### DIFF
--- a/src/ui/Topic.svelte
+++ b/src/ui/Topic.svelte
@@ -4,7 +4,7 @@
   export let topicList = [];
 </script>
 
-<div class="ons-card component-margin--2" aria-labelledBy="{id}-title" aria-describedBy="text">
+<div class="ons-card component-margin--2" role="region" aria-labelledBy="{id}-title" aria-describedBy="text">
   <h2 class="ons-u-fs-m" id="{id}-title">{cardTitle}</h2>
   <p id="{id}-text">
     <slot />


### PR DESCRIPTION
aria-labelledBy and aria-describedBy are not valid for the div element unless the element has a role of "region" or "complementary" in this case the correct role is "region". 

Research and fix took from: https://www.w3.org/TR/wai-aria-practices/examples/landmarks/region.html