### PR TITLE
Fix: Smart page titles.

### DIFF
--- a/src/routes/[topicSlug].svelte
+++ b/src/routes/[topicSlug].svelte
@@ -36,7 +36,7 @@
 </script>
 
 <svelte:head>
-  <title>2021 Census Data Atlas Topic</title>
+  <title>2021 Census Data Atlas Topic | {pageTopic.topicName}</title>
 </svelte:head>
 
 <BasePage>
@@ -58,9 +58,13 @@
   </span>
 
   <Topic topicList={pageTopic.suggestions} cardTitle="{pageTopic.topicName} - Census 2021"
-    ><p>The 2021 Census tells us a lot about the {pageTopic.topicName} of people living in England and Wales live and work.</p>
-    <p><a href="/categories/{topicSlug}"> Choose a category from the full list</a>
-    or explore one of these suggestions.</p>
+    ><p>
+      The 2021 Census tells us a lot about the {pageTopic.topicName} of people living in England and Wales live and work.
+    </p>
+    <p>
+      <a href="/categories/{topicSlug}"> Choose a category from the full list</a>
+      or explore one of these suggestions.
+    </p>
   </Topic>
 
   <ONSShare title="Share this page" pageURL={location.href} pageTitle={document.title} multiRow>

--- a/src/routes/[topicSlug]/[tableSlug]/[categorySlug].svelte
+++ b/src/routes/[topicSlug]/[tableSlug]/[categorySlug].svelte
@@ -137,7 +137,7 @@
 </script>
 
 <svelte:head>
-  <title>2021 Census Data Atlas Category & Location</title>
+  <title>2021 Census Data Atlas | {table ? table.name : ""} in {locationName || "England and Wales"}</title>
 </svelte:head>
 
 <BasePage>

--- a/src/routes/area/index.svelte
+++ b/src/routes/area/index.svelte
@@ -51,7 +51,7 @@
 </script>
 
 <svelte:head>
-  <title>2021 Census Data Atlas</title>
+  <title>2021 Census Data Atlas | {locationName} Census</title>
 </svelte:head>
 
 <BasePage>


### PR DESCRIPTION
There are page titles that are duplicated on multiple pages which may be confusing for screen reader users.

Screen reader comments:
“As I navigate through the service, I find that many of the page titles appear to have been named very similarly. I would prefer page titles to reflect page content more specifically.”

Solution:
Ensure that page titles are unique. This will ensure that screen reader users do not become disorientated.

Examples of this in practice.

https://deploy-preview-169--ons-data-map.netlify.app/health/general-health/very-good
https://deploy-preview-169--ons-data-map.netlify.app/area?location=E09000016
https://deploy-preview-169--ons-data-map.netlify.app/education

Signed off by design!