### PR TITLE
Fix/focus order 299

### DIFF
--- a/src/ui/BasePage.svelte
+++ b/src/ui/BasePage.svelte
@@ -59,10 +59,12 @@
           <slot name="header" />
         </div>
       {/if}
-      {#if (mobileMap && $$slots.map) || (!mobileMap && innerWidth >= config.ux.deviceWidth)}
-        <div class="map">
-          <slot name="map" />
-        </div>
+      {#if innerWidth < config.ux.deviceWidth}
+        {#if mobileMap && $$slots.map}
+          <div class="map">
+            <slot name="map" />
+          </div>
+        {/if}
       {/if}
       <div class="body">
         <slot name="body">
@@ -78,6 +80,11 @@
           </div>
         </slot>
       </div>
+      {#if innerWidth >= config.ux.deviceWidth}
+        <div class="map">
+          <slot name="map" />
+        </div>
+      {/if}
     </div>
   </div>
   <div bind:clientHeight={footerHeight}>


### PR DESCRIPTION
Issue:
Keyboard only users may be disorientated by the illogical focus order of the page. The interactive map receives keyboard focus after the ‘Cymraeg’ link. Users navigating with keyboard only inputs would expect to navigate the left side of the page before the interactive map

Tester only comments:
“I found an illogical tab order going from the (Cymraeg) link found at the top right-hand side of the page, then to the enlarge or decrease buttons for the map and followed by all the map controls before going back up the page to the ‘Choose a Category’ link found on the left-hand side of the page.”

Solution:
Re-ordered the map dom element for the tab index to flow through main content and then the map this is for desktop only. The mobile tab index will stay the same as is logical.