### PR TITLE
Fix: Keyboard control for show/hide.

### DIFF
--- a/src/ui/NestableCollapsible/NestableCollapsible.svelte
+++ b/src/ui/NestableCollapsible/NestableCollapsible.svelte
@@ -14,7 +14,6 @@
   class="ons-collapsible ons-collapsible--initialised {expandedCollapsible}"
   data-btn-close="Hide this"
   role="group"
-  aria-expanded={expanded}
 >
   <div
     {id}
@@ -27,6 +26,7 @@
     on:keyup={(event) => {
       if (event.key === "Enter") expanded = !expanded;
     }}
+    aria-expanded={expanded}
   >
     <div class="ons-collapsible__controls">
       <p class="ons-collapsible__title">{title ? `Show ${title} options` : ""}</p>

--- a/src/ui/NestableCollapsible/NestableCollapsible.svelte
+++ b/src/ui/NestableCollapsible/NestableCollapsible.svelte
@@ -24,6 +24,9 @@
     tabindex="0"
     data-ga-action={dataAction}
     on:click={() => (expanded = !expanded)}
+    on:keyup={(event) => {
+      if (event.key === "Enter") expanded = !expanded;
+    }}
   >
     <div class="ons-collapsible__controls">
       <p class="ons-collapsible__title">{title ? `Show ${title} options` : ""}</p>


### PR DESCRIPTION
Fixed two issues:

Issue 1:  
The sub-category link ‘Show travel to work options’ within the ‘Travel to work’ category cannot be activated with keyboard inputs. Keyboard-only users may be unable to expand the section, and this may also stop the user from using the site. There are multiple instances of similar sub-category links that do not work on the page.

Tester Comments:
"I can navigate to the link labeled (Show Travel to Work Options) and it receives focus indication however I am unable to click on it as it seems to be mouse dependent."

Solution: 
Added a `keyup` event listener to the div and wait for the "Enter" key to either expand or hide the subcategories. 


Issue 2:
Each section that can be expanded contains another section that can also be expanded. The secondary section does not announce an expanded or collapsed state to screen reader users. This could leave these users unaware that content expands and collapses. There are multiple expandable elements on the page.

Screen reader comments:
“When selecting any of the sub-category drop downs, there is no information to indicate that the content can be expanded or collapsed.”

Solution:
Moved the aria-expanded attribute to the correct div element. 