### PR TITLE
content-csv-to-json makes atlas content JSON from csv files

### DIFF
--- a/content-csv-to-json/.gitignore
+++ b/content-csv-to-json/.gitignore
@@ -1,0 +1,2 @@
+.python-version
+*.csv

--- a/content-csv-to-json/README.md
+++ b/content-csv-to-json/README.md
@@ -1,8 +1,11 @@
-# GENERATING CONTENT JSON FILE FROM CONTENT CSVs
+
+# Generating the content JSON file from the content spreadsheet
 
 ## Intro
 
-Census Atlas 'content' (metadata for rendering for user - plain english data labels, descriptions, templated content strings etc) is defined in a shared google worksheet(s), e.g. here: https://docs.google.com/spreadsheets/d/1AD0LGGfPEO2vDRBYWxoEEAf5fjILV9TaUrctHexyhT0/edit#gid=1924886616
+Census Atlas 'content' (metadata for the UI - plain english data labels, descriptions, templated content strings etc) is defined in a shared google worksheet(s), e.g. here: https://docs.google.com/spreadsheets/d/1AD0LGGfPEO2vDRBYWxoEEAf5fjILV9TaUrctHexyhT0/edit#gid=1924886616
+
+This script creates a JSON file that is bundled with the app.
 
 ## Dependencies
 
@@ -16,11 +19,11 @@ Requires Python 3.9+ to be available as the default `Python` executable in the c
 
 To create a json file making this content available to the atlas:
 
-1.  Download the relevant tab from the worksheet into a csv file (file -> download -> Comma Seperated Values (.csv))
-2.  Run content_csv_to_json.py with `./content_csv_to_json.py {path to your file here}` (NB - uses standard library Python, so doesn't need any dependencies install other than Python 3.9+)
-3.  This will create a JSON file in the content-csvs folder, named `{your filename}.content.json` (with the `csv` extension removed). The `meta.source` value will reference the csv file used to create the JSON.
-4.  Validate that all census data codes in the content JSON are available on the API with `./validate_content_json.py {your filename}.content.json`. This will call the API with each code and check the data is available.
-5.  Copy the contents of `{your filename}.content.json` into the atlas config file - at time of writing, `src/data/apiMetadata.js`
+1. Download the relevant tab from the worksheet into a csv file (file -> download -> Comma Seperated Values (.csv))
+2. Run content_csv_to_json.py with `./content_csv_to_json.py {path to your file here}` (NB - uses standard library Python, so doesn't need any dependencies install other than Python 3.9+)
+3. This will create a JSON file in the content-csvs folder, named `{your filename}.content.json` (with the `csv` extension removed). The `meta.source` value will reference the csv file used to create the JSON.
+4. Validate that all census data codes in the content JSON are available on the API with `./validate_content_json.py {your filename}.content.json`. This will call the API with each code and check the data is available.
+5. Copy the contents of `{your filename}.content.json` into the atlas config file - at time of writing, `src/data/apiMetadata.js`
 
 ## Tests
 

--- a/content-csv-to-json/README.md
+++ b/content-csv-to-json/README.md
@@ -1,0 +1,31 @@
+# GENERATING CONTENT JSON FILE FROM CONTENT CSVs
+
+## Intro
+
+Census Atlas 'content' (metadata for rendering for user - plain english data labels, descriptions, templated content strings etc) is defined in a shared google worksheet(s), e.g. here: https://docs.google.com/spreadsheets/d/1AD0LGGfPEO2vDRBYWxoEEAf5fjILV9TaUrctHexyhT0/edit#gid=1924886616
+
+## Dependencies
+
+Requires Python 3.9+ to be available as the default `Python` executable in the current environment. Can be installed as follows (macOS):
+
+- brew install pyenv
+- pyenv install 3.10.0
+- pyenv local 3.10.0
+
+## Instructions
+
+To create a json file making this content available to the atlas:
+
+1.  Download the relevant tab from the worksheet into a csv file (file -> download -> Comma Seperated Values (.csv))
+2.  Run content_csv_to_json.py with `./content_csv_to_json.py {path to your file here}` (NB - uses standard library Python, so doesn't need any dependencies install other than Python 3.9+)
+3.  This will create a JSON file in the content-csvs folder, named `{your filename}.content.json` (with the `csv` extension removed). The `meta.source` value will reference the csv file used to create the JSON.
+4.  Validate that all census data codes in the content JSON are available on the API with `./validate_content_json.py {your filename}.content.json`. This will call the API with each code and check the data is available.
+5.  Copy the contents of `{your filename}.content.json` into the atlas config file - at time of writing, `src/data/apiMetadata.js`
+
+## Tests
+
+To run test for the python scripts in this directory, run `python -m unittest` (assuming you have python 3.9+ available - see 'Dependencies')
+
+## ToDos
+
+Translate this into go!

--- a/content-csv-to-json/README.md
+++ b/content-csv-to-json/README.md
@@ -9,11 +9,11 @@ This script creates a JSON file that is bundled with the app.
 
 ## Dependencies
 
-Requires Python 3.9+ to be available as the default `Python` executable in the current environment. Can be installed as follows (macOS):
+Requires Python 3.9+ to be available as the default `Python` executable in the current environment. Can be installed and set as the local python as follows (macOS):
 
 - brew install pyenv
 - pyenv install 3.10.0
-- pyenv local 3.10.0
+- cd content-csv-to-json && pyenv local 3.10.0
 
 ## Instructions
 

--- a/content-csv-to-json/content_csv_to_json.py
+++ b/content-csv-to-json/content_csv_to_json.py
@@ -11,13 +11,13 @@ from typing import Iterator
 
 TAXONOMIC_ORDER = [
     "topic",
-    "classification",
+    "table",
     "category",
     "sub-category",
 ]
 NESTED_KEYS = {
-    "topic": "classifications",
-    "classification": "categories",
+    "topic": "tables",
+    "table": "categories",
     "category": "sub-categories",
     "sub-category": None
 }

--- a/content-csv-to-json/content_csv_to_json.py
+++ b/content-csv-to-json/content_csv_to_json.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+
+import json
+import pathlib
+import re
+import sys
+
+from csv import DictReader
+from typing import Iterator
+
+
+TAXONOMIC_ORDER = [
+    "topic",
+    "classification",
+    "category",
+    "sub-category",
+]
+NESTED_KEYS = {
+    "topic": "classifications",
+    "classification": "categories",
+    "category": "sub-categories",
+    "sub-category": None
+}
+DESC_PLACEHOLDER = "Lorem ipsum dolor sit amet."
+
+
+def slugify(name: str) -> str:
+    return "-".join(re.sub(r"[^a-zA-Z0-9]", " ", name.lower()).split())
+
+
+def is_nested(row, rows: list[dict], i: int) -> bool:
+    if i >= len(rows):
+        return False
+    return TAXONOMIC_ORDER.index(rows[i]["taxonomy"]) > TAXONOMIC_ORDER.index(row["taxonomy"])
+
+
+def is_total_category(content: dict) -> bool:
+    return content["code"].endswith("0001")
+
+
+def process_census_content(rows: list[dict], i: int) -> (dict, int):
+    # extract current row
+    row = rows[i]
+
+    # init content dict
+    content = {
+        "code": row["code"],
+        "name": row["name"],
+        "desc": DESC_PLACEHOLDER if row["desc"] == "" else row["desc"],
+        "slug": slugify(row["name"]),
+        "display_taxonomy": row["display taxonomy"]
+    }
+
+    # append units if present
+    if row["units"] != "":
+        content["units"] = row["units"]
+    
+    # deal with nested content using lookahead
+    i+=1
+    nested_key = NESTED_KEYS[row["taxonomy"]]
+    while is_nested(row, rows, i):
+        if nested_key not in content:
+            content[nested_key] = []
+        next_content, i = process_census_content(rows, i)
+        if is_total_category(next_content):
+            content["total"] = next_content
+        else:
+            content[nested_key].append(next_content)
+
+    return content, i
+
+
+def main(fp: pathlib.PurePath):
+    with open(fp) as f:
+        # filter code-less rows out here:
+        rows = []
+        for row in DictReader(f):
+            if row["code"] == "":
+                print(f"Ignoring {row['taxonomy']} with no code: {row['name']}")
+                continue
+            rows.append(row)
+        output = {
+            "meta": {
+                "source": fp.name,
+            },
+            "content": []
+        }
+        i = 0
+        while i < len(rows):
+            content, i = process_census_content(rows, i)
+            output["content"].append(content)
+      
+    with open(fp.with_suffix(".content.json"), 'w') as f:
+       json.dump(output, f, indent=2)
+
+
+if __name__=="__main__":
+    fp = pathlib.PurePath(sys.argv[1])
+    main(fp)

--- a/content-csv-to-json/content_csv_to_json.py
+++ b/content-csv-to-json/content_csv_to_json.py
@@ -50,13 +50,17 @@ def process_census_content(rows: list[dict], i: int) -> (dict, int):
         "name": row["name"],
         "desc": DESC_PLACEHOLDER if row["desc"] == "" else row["desc"],
         "slug": slugify(row["name"]),
-        "display_taxonomy": row["display taxonomy"]
+        # "display_taxonomy": row["display taxonomy"]
     }
 
     # append units if present
     if row["units"] != "":
         content["units"] = row["units"]
     
+    # all tables should have units!
+    if row["taxonomy"] == "table" and row["units"] == "":
+        raise Exception(f"Table definition does not include units! {row}")
+
     # deal with nested content using lookahead
     i+=1
     nested_key = NESTED_KEYS[row["taxonomy"]]

--- a/content-csv-to-json/test_content_csv_to_json.py
+++ b/content-csv-to-json/test_content_csv_to_json.py
@@ -33,112 +33,108 @@ class TestContentCsvToJson(TestCase):
 
 
     def test_content_csv_to_json_OK_one_topic_no_subcategories(self):
-        # GIVEN we have written a csv with one topic and two classifications, each with two categories and one total
+        # GIVEN we have written a csv with one topic and two tables, each with two categories and one total
         self.write_test_CSV([
             ["code","taxonomy","display taxonomy","name","desc","units"],
             ["1", "topic","topic", "Topic 1", "Topic 1 desc.", ""],
-            ["1_1", "classification","category", "Class 1_1", "Class 1_1 desc.", "units_1"],
+            ["1_1", "table","category", "Class 1_1", "Class 1_1 desc.", "units_1"],
             ["1_1_0001", "category","subject", "Cat 1_1_0001", "Cat 1_1_0001 desc.", ""],
             ["1_1_0002", "category","subject", "Cat 1_1_0002", "Cat 1_1_0002 desc.", ""],
             ["1_1_0003", "category","subject", "Cat 1_1_0003", "Cat 1_1_0003 desc.", ""],
-            ["1_2", "classification","category", "Class 1_2", "Class 1_2 desc.", "units_2"],
+            ["1_2", "table","category", "Class 1_2", "Class 1_2 desc.", "units_2"],
             ["1_2_0001", "category","subject", "Cat 1_2_0001", "Cat 1_2_0001 desc.", ""],
             ["1_2_0002", "category","subject", "Cat 1_2_0002", "Cat 1_2_0002 desc.", ""],
             ["1_2_0003", "category","subject", "Cat 1_2_0003", "Cat 1_2_0003 desc.", ""],
         ])
        
         # WHEN we run the content_csv_to_json script
-        os.system(f"./content_csv_to_json.py {self.test_fp}")
+        os.system(f"./content_csv_to_json.py {self.test_fp} --no-metadata")
 
         # THEN we expect to get a properly formatted JSON back
-        expected = {
-            "meta": {
-                "source": self.test_fn
-            },
-            "content": [
-                {
-                    "code": "1",
-                    "name": "Topic 1",
-                    "slug": "topic-1",
-                    "desc": "Topic 1 desc.",
-                    "display_taxonomy": "topic",
-                    "classifications": [
-                        {
-                            "code": "1_1",
-                            "name": "Class 1_1",
-                            "slug": "class-1-1",
-                            "desc": "Class 1_1 desc.",
-                            "units": "units_1",
-                            "display_taxonomy": "category",
-                            "total": {
-                                "code": "1_1_0001",
-                                "name": "Cat 1_1_0001",
-                                "slug": "cat-1-1-0001",
-                                "desc": "Cat 1_1_0001 desc.",
+        expected = [
+            {
+                "code": "1",
+                "name": "Topic 1",
+                "slug": "topic-1",
+                "desc": "Topic 1 desc.",
+                "display_taxonomy": "topic",
+                "tables": [
+                    {
+                        "code": "1_1",
+                        "name": "Class 1_1",
+                        "slug": "class-1-1",
+                        "desc": "Class 1_1 desc.",
+                        "units": "units_1",
+                        "display_taxonomy": "category",
+                        "total": {
+                            "code": "1_1_0001",
+                            "name": "Cat 1_1_0001",
+                            "slug": "cat-1-1-0001",
+                            "desc": "Cat 1_1_0001 desc.",
+                            "display_taxonomy": "subject",
+                        },
+                        "categories": [
+                            {
+                                "code": "1_1_0002",
+                                "name": "Cat 1_1_0002",
+                                "slug": "cat-1-1-0002",
+                                "desc": "Cat 1_1_0002 desc.",
                                 "display_taxonomy": "subject",
                             },
-                            "categories": [
-                                {
-                                    "code": "1_1_0002",
-                                    "name": "Cat 1_1_0002",
-                                    "slug": "cat-1-1-0002",
-                                    "desc": "Cat 1_1_0002 desc.",
-                                    "display_taxonomy": "subject",
-                                },
-                                {
-                                    "code": "1_1_0003",
-                                    "name": "Cat 1_1_0003",
-                                    "slug": "cat-1-1-0003",
-                                    "desc": "Cat 1_1_0003 desc.",
-                                    "display_taxonomy": "subject"
-                                },
-                            ]
+                            {
+                                "code": "1_1_0003",
+                                "name": "Cat 1_1_0003",
+                                "slug": "cat-1-1-0003",
+                                "desc": "Cat 1_1_0003 desc.",
+                                "display_taxonomy": "subject"
+                            },
+                        ]
+                    },
+                    {
+                        "code": "1_2",
+                        "name": "Class 1_2",
+                        "slug": "class-1-2",
+                        "desc": "Class 1_2 desc.",
+                        "units": "units_2",
+                        "display_taxonomy": "category",
+                        "total": {
+                            "code": "1_2_0001",
+                            "name": "Cat 1_2_0001",
+                            "slug": "cat-1-2-0001",
+                            "desc": "Cat 1_2_0001 desc.",
+                            "display_taxonomy": "subject",
                         },
-                        {
-                            "code": "1_2",
-                            "name": "Class 1_2",
-                            "slug": "class-1-2",
-                            "desc": "Class 1_2 desc.",
-                            "units": "units_2",
-                            "display_taxonomy": "category",
-                            "total": {
-                                "code": "1_2_0001",
-                                "name": "Cat 1_2_0001",
-                                "slug": "cat-1-2-0001",
-                                "desc": "Cat 1_2_0001 desc.",
+                        "categories": [
+                            {
+                                "code": "1_2_0002",
+                                "name": "Cat 1_2_0002",
+                                "slug": "cat-1-2-0002",
+                                "desc": "Cat 1_2_0002 desc.",
                                 "display_taxonomy": "subject",
                             },
-                            "categories": [
-                                {
-                                    "code": "1_2_0002",
-                                    "name": "Cat 1_2_0002",
-                                    "slug": "cat-1-2-0002",
-                                    "desc": "Cat 1_2_0002 desc.",
-                                    "display_taxonomy": "subject",
-                                },
-                                {
-                                    "code": "1_2_0003",
-                                    "name": "Cat 1_2_0003",
-                                    "slug": "cat-1-2-0003",
-                                    "desc": "Cat 1_2_0003 desc.",
-                                    "display_taxonomy": "subject"
-                                },
-                            ]
-                        },
-                    ]
-                }
-            ]
-        }
+                            {
+                                "code": "1_2_0003",
+                                "name": "Cat 1_2_0003",
+                                "slug": "cat-1-2-0003",
+                                "desc": "Cat 1_2_0003 desc.",
+                                "display_taxonomy": "subject"
+                            },
+                        ]
+                    },
+                ]
+            }
+        ]
+
         returned = self.read_test_JSON()
         self.assertEqual(expected, returned)
 
     def test_content_csv_to_json_OK_subcategories(self):
-        # GIVEN we have written a csv with one topic and one classification with one category, one total and two 
+        # GIVEN we have written a csv with one topic and one table with one category, one total and two 
         # two subcategories
         self.write_test_CSV([
             ["code","taxonomy","display taxonomy","name","desc","units"],
             ["1", "topic","topic", "Topic 1", "Topic 1 desc.", ""],
-            ["1_1", "classification","category", "Class 1_1", "Class 1_1 desc.", "units_1"],
+            ["1_1", "table","category", "Class 1_1", "Class 1_1 desc.", "units_1"],
             ["1_1_0001", "category","subject", "Cat 1_1_0001", "Cat 1_1_0001 desc.", ""],
             ["1_1_0002", "category","subject", "Cat 1_1_0002", "Cat 1_1_0002 desc.", ""],
             ["1_1_0002_1", "sub-category","sub-subject", "Sub-Cat 1_1_0002_1", "Sub-Cat 1_1_0002_1 desc.", ""],
@@ -146,166 +142,173 @@ class TestContentCsvToJson(TestCase):
         ])
        
         # WHEN we run the content_csv_to_json script
-        os.system(f"./content_csv_to_json.py {self.test_fp}")
+        os.system(f"./content_csv_to_json.py {self.test_fp} --no-metadata")
 
         # THEN we expect to get a properly formatted JSON back
-        expected = {
-            "meta": {
-                "source": self.test_fn
-            },
-            "content": [
-                {
-                    "code": "1",
-                    "name": "Topic 1",
-                    "slug": "topic-1",
-                    "desc": "Topic 1 desc.",
-                    "display_taxonomy": "topic",
-                    "classifications": [
-                        {
-                            "code": "1_1",
-                            "name": "Class 1_1",
-                            "slug": "class-1-1",
-                            "desc": "Class 1_1 desc.",
-                            "units": "units_1",
-                            "display_taxonomy": "category",
-                            "total": {
-                                "code": "1_1_0001",
-                                "name": "Cat 1_1_0001",
-                                "slug": "cat-1-1-0001",
-                                "desc": "Cat 1_1_0001 desc.",
+        expected = [
+            {
+                "code": "1",
+                "name": "Topic 1",
+                "slug": "topic-1",
+                "desc": "Topic 1 desc.",
+                "display_taxonomy": "topic",
+                "tables": [
+                    {
+                        "code": "1_1",
+                        "name": "Class 1_1",
+                        "slug": "class-1-1",
+                        "desc": "Class 1_1 desc.",
+                        "units": "units_1",
+                        "display_taxonomy": "category",
+                        "total": {
+                            "code": "1_1_0001",
+                            "name": "Cat 1_1_0001",
+                            "slug": "cat-1-1-0001",
+                            "desc": "Cat 1_1_0001 desc.",
+                            "display_taxonomy": "subject",
+                        },
+                        "categories": [
+                            {
+                                "code": "1_1_0002",
+                                "name": "Cat 1_1_0002",
+                                "slug": "cat-1-1-0002",
+                                "desc": "Cat 1_1_0002 desc.",
                                 "display_taxonomy": "subject",
+                                "sub-categories": [
+                                    {
+                                        "code": "1_1_0002_1",
+                                        "name": "Sub-Cat 1_1_0002_1",
+                                        "slug": "sub-cat-1-1-0002-1",
+                                        "desc": "Sub-Cat 1_1_0002_1 desc.",
+                                        "display_taxonomy": "sub-subject"
+                                    },
+                                    {
+                                        "code": "1_1_0002_2",
+                                        "name": "Sub-Cat 1_1_0002_2",
+                                        "slug": "sub-cat-1-1-0002-2",
+                                        "desc": "Sub-Cat 1_1_0002_2 desc.",
+                                        "display_taxonomy": "sub-subject"
+                                    },
+                                    
+                                ]
                             },
-                            "categories": [
-                                {
-                                    "code": "1_1_0002",
-                                    "name": "Cat 1_1_0002",
-                                    "slug": "cat-1-1-0002",
-                                    "desc": "Cat 1_1_0002 desc.",
-                                    "display_taxonomy": "subject",
-                                    "sub-categories": [
-                                        {
-                                            "code": "1_1_0002_1",
-                                            "name": "Sub-Cat 1_1_0002_1",
-                                            "slug": "sub-cat-1-1-0002-1",
-                                            "desc": "Sub-Cat 1_1_0002_1 desc.",
-                                            "display_taxonomy": "sub-subject"
-                                        },
-                                        {
-                                            "code": "1_1_0002_2",
-                                            "name": "Sub-Cat 1_1_0002_2",
-                                            "slug": "sub-cat-1-1-0002-2",
-                                            "desc": "Sub-Cat 1_1_0002_2 desc.",
-                                            "display_taxonomy": "sub-subject"
-                                        },
-                                        
-                                    ]
-                                },
-                            ]
-                        }
-                    ]
-                }
-            ]
-        }
+                        ]
+                    }
+                ]
+            }
+        ]
         returned = self.read_test_JSON()
         self.assertEqual(expected, returned)
 
     def test_content_csv_to_json_blank_cat_desc_placeholder(self):
-        # GIVEN we have written a csv with one topic and one classification with one category, with blank desc values
+        # GIVEN we have written a csv with one topic and one table with one category, with blank desc values
         self.write_test_CSV([
             ["code","taxonomy","display taxonomy","name","desc","units"],
             ["1", "topic","topic", "Topic 1", "", ""],
-            ["1_1", "classification","category", "Class 1_1", "", "units_1"],
+            ["1_1", "table","category", "Class 1_1", "", "units_1"],
             ["1_1_0002", "category","subject", "Cat 1_1_0002", "", ""]
         ])
         
         # WHEN we run the content_csv_to_json script
-        os.system(f"./content_csv_to_json.py {self.test_fp}")
+        os.system(f"./content_csv_to_json.py {self.test_fp} --no-metadata")
 
         # THEN we expect to get a properly formatted JSON back, with lorem ipsum placeholder descriptions
-        expected = {
-            "meta": {
-                "source": self.test_fn
-            },
-            "content": [
-                {
-                    "code": "1",
-                    "name": "Topic 1",
-                    "slug": "topic-1",
-                    "desc": content_csv_to_json.DESC_PLACEHOLDER,
-                    "display_taxonomy": "topic",
-                    "classifications": [
-                        {
-                            "code": "1_1",
-                            "name": "Class 1_1",
-                            "slug": "class-1-1",
-                            "desc": content_csv_to_json.DESC_PLACEHOLDER,
-                            "units": "units_1",
-                            "display_taxonomy": "category",
-                            "categories": [
-                                {
-                                    "code": "1_1_0002",
-                                    "name": "Cat 1_1_0002",
-                                    "slug": "cat-1-1-0002",
-                                    "desc": content_csv_to_json.DESC_PLACEHOLDER,
-                                    "display_taxonomy": "subject"
-                                },
-                            ]
-                        }
-                    ]
-                }
-            ]
-        }
+        expected = [
+            {
+                "code": "1",
+                "name": "Topic 1",
+                "slug": "topic-1",
+                "desc": content_csv_to_json.DESC_PLACEHOLDER,
+                "display_taxonomy": "topic",
+                "tables": [
+                    {
+                        "code": "1_1",
+                        "name": "Class 1_1",
+                        "slug": "class-1-1",
+                        "desc": content_csv_to_json.DESC_PLACEHOLDER,
+                        "units": "units_1",
+                        "display_taxonomy": "category",
+                        "categories": [
+                            {
+                                "code": "1_1_0002",
+                                "name": "Cat 1_1_0002",
+                                "slug": "cat-1-1-0002",
+                                "desc": content_csv_to_json.DESC_PLACEHOLDER,
+                                "display_taxonomy": "subject"
+                            },
+                        ]
+                    }
+                ]
+            }
+        ]
+
         returned = self.read_test_JSON()
         self.assertEqual(expected, returned)
 
 
     def test_content_csv_to_json_ignores_content_with_no_code(self):
-        # GIVEN we have written a csv with one topic and two classifications with one category, one set with blank codes
+        # GIVEN we have written a csv with one topic and two tables with one category, one set with blank codes
         self.write_test_CSV([
             ["code","taxonomy","display taxonomy","name","desc","units"],
             ["1", "topic","topic", "Topic 1", "Topic 1 desc.", ""],
-            ["1_1", "classification","category", "Class 1_1", "Class 1_1 desc.", "units_1"],
+            ["1_1", "table","category", "Class 1_1", "Class 1_1 desc.", "units_1"],
             ["1_1_0002", "category","subject", "Cat 1_1_0002", "Cat 1_1_0002 desc.", ""],
-            ["", "classification","category", "Class 1_2", "Class 1_2 desc.", "units_2"],
+            ["", "table","category", "Class 1_2", "Class 1_2 desc.", "units_2"],
             ["", "category","subject", "Cat 1_2_0002", "Cat 1_1_0002 desc.", ""]
         ])
         
         # WHEN we run the content_csv_to_json script
-        os.system(f"./content_csv_to_json.py {self.test_fp}")
+        os.system(f"./content_csv_to_json.py {self.test_fp} --no-metadata")
 
         # THEN we expect to get a properly formatted JSON back, with the blank code entries ignored
-        expected = {
-            "meta": {
-                "source": self.test_fn
-            },
-            "content": [
-                {
-                    "code": "1",
-                    "name": "Topic 1",
-                    "slug": "topic-1",
-                    "desc": "Topic 1 desc.",
-                    "display_taxonomy": "topic",
-                    "classifications": [
-                        {
-                            "code": "1_1",
-                            "name": "Class 1_1",
-                            "slug": "class-1-1",
-                            "desc": "Class 1_1 desc.",
-                            "units": "units_1",
-                            "display_taxonomy": "category",
-                            "categories": [
-                                {
-                                    "code": "1_1_0002",
-                                    "name": "Cat 1_1_0002",
-                                    "slug": "cat-1-1-0002",
-                                    "desc": "Cat 1_1_0002 desc.",
-                                    "display_taxonomy": "subject"
-                                },
-                            ]
-                        }
-                    ]
-                }
-            ]
-        }
+        expected = [
+            {
+                "code": "1",
+                "name": "Topic 1",
+                "slug": "topic-1",
+                "desc": "Topic 1 desc.",
+                "display_taxonomy": "topic",
+                "tables": [
+                    {
+                        "code": "1_1",
+                        "name": "Class 1_1",
+                        "slug": "class-1-1",
+                        "desc": "Class 1_1 desc.",
+                        "units": "units_1",
+                        "display_taxonomy": "category",
+                        "categories": [
+                            {
+                                "code": "1_1_0002",
+                                "name": "Cat 1_1_0002",
+                                "slug": "cat-1-1-0002",
+                                "desc": "Cat 1_1_0002 desc.",
+                                "display_taxonomy": "subject"
+                            },
+                        ]
+                    }
+                ]
+            }
+        ]
+
         returned = self.read_test_JSON()
         self.assertEqual(expected, returned)
+
+    def test_content_csv_to_json_writes_metadata(self):
+        # GIVEN we have written a csv with one topic and two tables with one category, one set with blank codes
+        self.write_test_CSV([
+            ["code","taxonomy","display taxonomy","name","desc","units"],
+            ["1", "topic","topic", "Topic 1", "Topic 1 desc.", ""],
+            ["1_1", "table","category", "Class 1_1", "Class 1_1 desc.", "units_1"],
+            ["1_1_0002", "category","subject", "Cat 1_1_0002", "Cat 1_1_0002 desc.", ""],
+            ["", "table","category", "Class 1_2", "Class 1_2 desc.", "units_2"],
+            ["", "category","subject", "Cat 1_2_0002", "Cat 1_1_0002 desc.", ""]
+        ])
+
+        # WHEN we run the content_csv_to_json script WITHOUT the no-metadata flag
+        os.system(f"./content_csv_to_json.py {self.test_fp}")
+
+        # THEN we expect to get a meta key back, with a filepath equal to that called and a timestamp 
+        returned = self.read_test_JSON()
+        self.assertTrue("meta" in returned)
+        self.assertEqual(returned["meta"]["source"], self.test_fn)
+        self.assertTrue("utc_created_at" in returned["meta"])

--- a/content-csv-to-json/test_content_csv_to_json.py
+++ b/content-csv-to-json/test_content_csv_to_json.py
@@ -1,0 +1,311 @@
+import csv
+import json
+import os
+import pathlib
+import shutil
+import tempfile
+
+from unittest import TestCase
+
+import content_csv_to_json
+
+
+class TestContentCsvToJson(TestCase):
+
+    def setUp(self):
+        self.maxDiff = None
+        self.test_dir = tempfile.TemporaryDirectory()
+        self.test_fn = "test.csv"
+        self.test_fp = pathlib.PurePath(self.test_dir.name, self.test_fn)
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir.name)
+
+    def write_test_CSV(self, csvRowList):
+        with open(self.test_fp, 'w') as f:
+            writer = csv.writer(f)
+            writer.writerows(csvRowList)
+
+    def read_test_JSON(self):
+        with open(self.test_fp.with_suffix(".content.json"), 'r') as f:
+            json_contents = json.load(f)
+        return json_contents
+
+
+    def test_content_csv_to_json_OK_one_topic_no_subcategories(self):
+        # GIVEN we have written a csv with one topic and two classifications, each with two categories and one total
+        self.write_test_CSV([
+            ["code","taxonomy","display taxonomy","name","desc","units"],
+            ["1", "topic","topic", "Topic 1", "Topic 1 desc.", ""],
+            ["1_1", "classification","category", "Class 1_1", "Class 1_1 desc.", "units_1"],
+            ["1_1_0001", "category","subject", "Cat 1_1_0001", "Cat 1_1_0001 desc.", ""],
+            ["1_1_0002", "category","subject", "Cat 1_1_0002", "Cat 1_1_0002 desc.", ""],
+            ["1_1_0003", "category","subject", "Cat 1_1_0003", "Cat 1_1_0003 desc.", ""],
+            ["1_2", "classification","category", "Class 1_2", "Class 1_2 desc.", "units_2"],
+            ["1_2_0001", "category","subject", "Cat 1_2_0001", "Cat 1_2_0001 desc.", ""],
+            ["1_2_0002", "category","subject", "Cat 1_2_0002", "Cat 1_2_0002 desc.", ""],
+            ["1_2_0003", "category","subject", "Cat 1_2_0003", "Cat 1_2_0003 desc.", ""],
+        ])
+       
+        # WHEN we run the content_csv_to_json script
+        os.system(f"./content_csv_to_json.py {self.test_fp}")
+
+        # THEN we expect to get a properly formatted JSON back
+        expected = {
+            "meta": {
+                "source": self.test_fn
+            },
+            "content": [
+                {
+                    "code": "1",
+                    "name": "Topic 1",
+                    "slug": "topic-1",
+                    "desc": "Topic 1 desc.",
+                    "display_taxonomy": "topic",
+                    "classifications": [
+                        {
+                            "code": "1_1",
+                            "name": "Class 1_1",
+                            "slug": "class-1-1",
+                            "desc": "Class 1_1 desc.",
+                            "units": "units_1",
+                            "display_taxonomy": "category",
+                            "total": {
+                                "code": "1_1_0001",
+                                "name": "Cat 1_1_0001",
+                                "slug": "cat-1-1-0001",
+                                "desc": "Cat 1_1_0001 desc.",
+                                "display_taxonomy": "subject",
+                            },
+                            "categories": [
+                                {
+                                    "code": "1_1_0002",
+                                    "name": "Cat 1_1_0002",
+                                    "slug": "cat-1-1-0002",
+                                    "desc": "Cat 1_1_0002 desc.",
+                                    "display_taxonomy": "subject",
+                                },
+                                {
+                                    "code": "1_1_0003",
+                                    "name": "Cat 1_1_0003",
+                                    "slug": "cat-1-1-0003",
+                                    "desc": "Cat 1_1_0003 desc.",
+                                    "display_taxonomy": "subject"
+                                },
+                            ]
+                        },
+                        {
+                            "code": "1_2",
+                            "name": "Class 1_2",
+                            "slug": "class-1-2",
+                            "desc": "Class 1_2 desc.",
+                            "units": "units_2",
+                            "display_taxonomy": "category",
+                            "total": {
+                                "code": "1_2_0001",
+                                "name": "Cat 1_2_0001",
+                                "slug": "cat-1-2-0001",
+                                "desc": "Cat 1_2_0001 desc.",
+                                "display_taxonomy": "subject",
+                            },
+                            "categories": [
+                                {
+                                    "code": "1_2_0002",
+                                    "name": "Cat 1_2_0002",
+                                    "slug": "cat-1-2-0002",
+                                    "desc": "Cat 1_2_0002 desc.",
+                                    "display_taxonomy": "subject",
+                                },
+                                {
+                                    "code": "1_2_0003",
+                                    "name": "Cat 1_2_0003",
+                                    "slug": "cat-1-2-0003",
+                                    "desc": "Cat 1_2_0003 desc.",
+                                    "display_taxonomy": "subject"
+                                },
+                            ]
+                        },
+                    ]
+                }
+            ]
+        }
+        returned = self.read_test_JSON()
+        self.assertEqual(expected, returned)
+
+    def test_content_csv_to_json_OK_subcategories(self):
+        # GIVEN we have written a csv with one topic and one classification with one category, one total and two 
+        # two subcategories
+        self.write_test_CSV([
+            ["code","taxonomy","display taxonomy","name","desc","units"],
+            ["1", "topic","topic", "Topic 1", "Topic 1 desc.", ""],
+            ["1_1", "classification","category", "Class 1_1", "Class 1_1 desc.", "units_1"],
+            ["1_1_0001", "category","subject", "Cat 1_1_0001", "Cat 1_1_0001 desc.", ""],
+            ["1_1_0002", "category","subject", "Cat 1_1_0002", "Cat 1_1_0002 desc.", ""],
+            ["1_1_0002_1", "sub-category","sub-subject", "Sub-Cat 1_1_0002_1", "Sub-Cat 1_1_0002_1 desc.", ""],
+            ["1_1_0002_2", "sub-category","sub-subject", "Sub-Cat 1_1_0002_2", "Sub-Cat 1_1_0002_2 desc.", ""]
+        ])
+       
+        # WHEN we run the content_csv_to_json script
+        os.system(f"./content_csv_to_json.py {self.test_fp}")
+
+        # THEN we expect to get a properly formatted JSON back
+        expected = {
+            "meta": {
+                "source": self.test_fn
+            },
+            "content": [
+                {
+                    "code": "1",
+                    "name": "Topic 1",
+                    "slug": "topic-1",
+                    "desc": "Topic 1 desc.",
+                    "display_taxonomy": "topic",
+                    "classifications": [
+                        {
+                            "code": "1_1",
+                            "name": "Class 1_1",
+                            "slug": "class-1-1",
+                            "desc": "Class 1_1 desc.",
+                            "units": "units_1",
+                            "display_taxonomy": "category",
+                            "total": {
+                                "code": "1_1_0001",
+                                "name": "Cat 1_1_0001",
+                                "slug": "cat-1-1-0001",
+                                "desc": "Cat 1_1_0001 desc.",
+                                "display_taxonomy": "subject",
+                            },
+                            "categories": [
+                                {
+                                    "code": "1_1_0002",
+                                    "name": "Cat 1_1_0002",
+                                    "slug": "cat-1-1-0002",
+                                    "desc": "Cat 1_1_0002 desc.",
+                                    "display_taxonomy": "subject",
+                                    "sub-categories": [
+                                        {
+                                            "code": "1_1_0002_1",
+                                            "name": "Sub-Cat 1_1_0002_1",
+                                            "slug": "sub-cat-1-1-0002-1",
+                                            "desc": "Sub-Cat 1_1_0002_1 desc.",
+                                            "display_taxonomy": "sub-subject"
+                                        },
+                                        {
+                                            "code": "1_1_0002_2",
+                                            "name": "Sub-Cat 1_1_0002_2",
+                                            "slug": "sub-cat-1-1-0002-2",
+                                            "desc": "Sub-Cat 1_1_0002_2 desc.",
+                                            "display_taxonomy": "sub-subject"
+                                        },
+                                        
+                                    ]
+                                },
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+        returned = self.read_test_JSON()
+        self.assertEqual(expected, returned)
+
+    def test_content_csv_to_json_blank_cat_desc_placeholder(self):
+        # GIVEN we have written a csv with one topic and one classification with one category, with blank desc values
+        self.write_test_CSV([
+            ["code","taxonomy","display taxonomy","name","desc","units"],
+            ["1", "topic","topic", "Topic 1", "", ""],
+            ["1_1", "classification","category", "Class 1_1", "", "units_1"],
+            ["1_1_0002", "category","subject", "Cat 1_1_0002", "", ""]
+        ])
+        
+        # WHEN we run the content_csv_to_json script
+        os.system(f"./content_csv_to_json.py {self.test_fp}")
+
+        # THEN we expect to get a properly formatted JSON back, with lorem ipsum placeholder descriptions
+        expected = {
+            "meta": {
+                "source": self.test_fn
+            },
+            "content": [
+                {
+                    "code": "1",
+                    "name": "Topic 1",
+                    "slug": "topic-1",
+                    "desc": content_csv_to_json.DESC_PLACEHOLDER,
+                    "display_taxonomy": "topic",
+                    "classifications": [
+                        {
+                            "code": "1_1",
+                            "name": "Class 1_1",
+                            "slug": "class-1-1",
+                            "desc": content_csv_to_json.DESC_PLACEHOLDER,
+                            "units": "units_1",
+                            "display_taxonomy": "category",
+                            "categories": [
+                                {
+                                    "code": "1_1_0002",
+                                    "name": "Cat 1_1_0002",
+                                    "slug": "cat-1-1-0002",
+                                    "desc": content_csv_to_json.DESC_PLACEHOLDER,
+                                    "display_taxonomy": "subject"
+                                },
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+        returned = self.read_test_JSON()
+        self.assertEqual(expected, returned)
+
+
+    def test_content_csv_to_json_ignores_content_with_no_code(self):
+        # GIVEN we have written a csv with one topic and two classifications with one category, one set with blank codes
+        self.write_test_CSV([
+            ["code","taxonomy","display taxonomy","name","desc","units"],
+            ["1", "topic","topic", "Topic 1", "Topic 1 desc.", ""],
+            ["1_1", "classification","category", "Class 1_1", "Class 1_1 desc.", "units_1"],
+            ["1_1_0002", "category","subject", "Cat 1_1_0002", "Cat 1_1_0002 desc.", ""],
+            ["", "classification","category", "Class 1_2", "Class 1_2 desc.", "units_2"],
+            ["", "category","subject", "Cat 1_2_0002", "Cat 1_1_0002 desc.", ""]
+        ])
+        
+        # WHEN we run the content_csv_to_json script
+        os.system(f"./content_csv_to_json.py {self.test_fp}")
+
+        # THEN we expect to get a properly formatted JSON back, with the blank code entries ignored
+        expected = {
+            "meta": {
+                "source": self.test_fn
+            },
+            "content": [
+                {
+                    "code": "1",
+                    "name": "Topic 1",
+                    "slug": "topic-1",
+                    "desc": "Topic 1 desc.",
+                    "display_taxonomy": "topic",
+                    "classifications": [
+                        {
+                            "code": "1_1",
+                            "name": "Class 1_1",
+                            "slug": "class-1-1",
+                            "desc": "Class 1_1 desc.",
+                            "units": "units_1",
+                            "display_taxonomy": "category",
+                            "categories": [
+                                {
+                                    "code": "1_1_0002",
+                                    "name": "Cat 1_1_0002",
+                                    "slug": "cat-1-1-0002",
+                                    "desc": "Cat 1_1_0002 desc.",
+                                    "display_taxonomy": "subject"
+                                },
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+        returned = self.read_test_JSON()
+        self.assertEqual(expected, returned)

--- a/content-csv-to-json/test_validate_content_json.py
+++ b/content-csv-to-json/test_validate_content_json.py
@@ -1,0 +1,127 @@
+
+import csv
+import json
+import pathlib
+import random
+import string
+import shutil
+import tempfile
+
+from unittest import TestCase
+from unittest.mock import call, patch
+
+import validate_content_json
+
+
+class TestValidateContentJSON(TestCase):
+
+    def setUp(self):
+        self.maxDiff = None
+        self.test_dir = tempfile.TemporaryDirectory()
+        self.test_fn = "test.json"
+        self.test_fp = pathlib.PurePath(self.test_dir.name, self.test_fn)
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir.name)
+
+    def write_test_JSON(self, test_json):
+        with open(self.test_fp, 'w') as f:
+            json.dump(test_json, f, indent=2)
+
+    def generate_valid_codes(self, n):
+        output = []
+        for _ in range(n):
+            output.append(''.join(random.choices(string.ascii_uppercase + string.digits, k=11)))
+        return output
+
+    @patch('validate_content_json.check_requestable_code')
+    def test_content_csv_to_json_OK_one_topic_no_subcategories(self, mock_requestable_code):
+        # GIVEN we have written a csv with one topic and two classifications, each with two categories and one total
+        valid_codes = self.generate_valid_codes(6)
+        self.write_test_JSON({
+            "meta": {
+                "source": self.test_fn
+            },
+            "content": [
+                {
+                    "code": "1",
+                    "name": "Topic 1",
+                    "slug": "topic-1",
+                    "desc": "Topic 1 desc.",
+                    "display_taxonomy": "topic",
+                    "classifications": [
+                        {
+                            "code": "1_1",
+                            "name": "Class 1_1",
+                            "slug": "class-1-1",
+                            "desc": "Class 1_1 desc.",
+                            "units": "units_1",
+                            "display_taxonomy": "category",
+                            "total": {
+                                "code": valid_codes[0],
+                                "name": "Cat 1_1_0001",
+                                "slug": "cat-1-1-0001",
+                                "desc": "Cat 1_1_0001 desc.",
+                                "display_taxonomy": "subject",
+                            },
+                            "categories": [
+                                {
+                                    "code": valid_codes[1],
+                                    "name": "Cat 1_1_0002",
+                                    "slug": "cat-1-1-0002",
+                                    "desc": "Cat 1_1_0002 desc.",
+                                    "display_taxonomy": "subject",
+                                },
+                                {
+                                    "code": valid_codes[2],
+                                    "name": "Cat 1_1_0003",
+                                    "slug": "cat-1-1-0003",
+                                    "desc": "Cat 1_1_0003 desc.",
+                                    "display_taxonomy": "subject"
+                                },
+                            ]
+                        },
+                        {
+                            "code": "1_2",
+                            "name": "Class 1_2",
+                            "slug": "class-1-2",
+                            "desc": "Class 1_2 desc.",
+                            "units": "units_2",
+                            "display_taxonomy": "category",
+                            "total": {
+                                "code": valid_codes[3],
+                                "name": "Cat 1_2_0001",
+                                "slug": "cat-1-2-0001",
+                                "desc": "Cat 1_2_0001 desc.",
+                                "display_taxonomy": "subject",
+                            },
+                            "categories": [
+                                {
+                                    "code": valid_codes[4],
+                                    "name": "Cat 1_2_0002",
+                                    "slug": "cat-1-2-0002",
+                                    "desc": "Cat 1_2_0002 desc.",
+                                    "display_taxonomy": "subject",
+                                },
+                                {
+                                    "code": valid_codes[5],
+                                    "name": "Cat 1_2_0003",
+                                    "slug": "cat-1-2-0003",
+                                    "desc": "Cat 1_2_0003 desc.",
+                                    "display_taxonomy": "subject"
+                                },
+                            ]
+                        },
+                    ]
+                }
+            ]
+        })
+       
+        # WHEN we run the validation function
+        validate_content_json.main(self.test_fp)
+
+        # THEN we expect out mock to have been called with all the codes in the above json
+        self.assertEqual(mock_requestable_code.call_count, len(valid_codes)) 
+        for code in valid_codes:
+            mock_requestable_code.assert_any_call(code)
+            

--- a/content-csv-to-json/validate_content_json.py
+++ b/content-csv-to-json/validate_content_json.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+
+import json
+import pathlib
+import sys
+import urllib.request
+
+
+BASE_URL = "https://cep5lmkia0.execute-api.eu-west-1.amazonaws.com/dev/query/2011?cols={}&rows=all&geotype=LAD"
+
+CODES_WITH_ERRORS = []
+
+def content_crawler(content):
+    # if list, feed all into self
+    if isinstance(content, list):
+        for nested_content in content:
+            content_crawler(nested_content)
+    else:
+        for k, v in content.items():
+            
+            # if dict, feed single into self
+            if isinstance(v, dict):
+                content_crawler(v)
+            
+            # if list, feed all into self
+            elif isinstance(v, list):
+                for nested_content in v:
+                    content_crawler(nested_content)
+            
+            # if single value, check
+            elif is_requestable_code(k, v):
+                if not check_requestable_code(v):
+                    CODES_WITH_ERRORS.append(v)
+
+
+def is_requestable_code(key, value):
+    return key == "code" and len(value) == 11
+
+
+def check_requestable_code(code):
+    print(".", end = '', flush=True)
+    request_url = BASE_URL.format(code)
+    resp = urllib.request.urlopen(request_url)
+    if resp.status != 200:
+        return False
+    return True
+
+
+def main(fp):
+    # load JSON
+    with open(fp) as f:
+        content_json = json.load(f)
+
+    # crawl through all categories, sub-categories and totals
+    print("Checking all census data codes are available from API", end = '', flush=True)
+    content_crawler(content_json)
+
+    # report
+    print("")
+    if len(CODES_WITH_ERRORS) > 0:
+        print(f"These census data codes returnd non-200 status when requested from the API: {CODES_WITH_ERRORS}")
+    else:
+        print("All census data codes in the content JSON were found on the API.")
+
+if __name__=="__main__":
+    fp = pathlib.PurePath(sys.argv[1])
+    main(fp)


### PR DESCRIPTION
commit d80510d2fff0bc0c8ca61b6a359bacd271c1a029 (HEAD -> feature/make-validate-content-json-from-csv, origin/feature/make-validate-content-json-from-csv)
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Thu Mar 10 13:15:08 2022 +0000

    add created at timestamp to content_csv_to_json output, make metadata optional

commit bc7a5e4b545f3be6e07205cea29b795439505c0b
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Thu Mar 10 12:07:15 2022 +0000

    revert classification -> table in content_csv_to_json.py

commit a8b9603f6917c09c010420016e93965c988518df (HEAD -> feature/make-validate-content-json-from-csv, origin/feature/make-validate-content-json-from-csv)
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Wed Mar 9 15:42:05 2022 +0000

    content-csv-to-json makes atlas content JSON from csv files

    content-csv-to-json dir added with following:

    - content_csv_to_json.py (python3): converts csv files with content
    (data labels, descriptive text etc) downloaded from spreadsheet
    shared with design team to JSON consumable by atlas.

    - validate_content_json.oy (python3): Checks that all census data
    referenced in the output of content_csv_to_json.py is available from
    the dp-geodata-api.

    Misc:
    - added csv file for v4_1 content to content-csvs directory
    - tests added (run python -m unittest from the content-csv-to-json dir)

    These changed needed to streamline getting content from design team
    to front end.