### PR TITLE
Updates the title of the suggestion component on home screen-ticket#370

### DIFF
--- a/src/ui/SelectTopic.svelte
+++ b/src/ui/SelectTopic.svelte
@@ -13,7 +13,7 @@
   <div class="ons-u-mb-l">
     <TopicList />
   </div>
-  <ONSCollapsible isRegularFontWeightTitle title="Popular topic searches" a11yHeading>
+  <ONSCollapsible isRegularFontWeightTitle title="Popular searches" a11yHeading>
     {#each suggestions as suggestion}
       <p><a href={suggestion.url}>{suggestion.text}</a></p>
     {/each}


### PR DESCRIPTION
**What**

Updates the title of the suggestion component on the home screen from `Popular topic searches` to `Popular searches`.

![Screenshot 2022-03-10 at 16 09 50](https://user-images.githubusercontent.com/70764326/157706883-a9ce0edf-b0d8-401f-b571-428840bcc088.png)

