### PR TITLE
Fixes the browser back button - ticket#345

### DIFF
--- a/src/routes/[topicSlug].svelte
+++ b/src/routes/[topicSlug].svelte
@@ -43,10 +43,12 @@
 
   $: {
     if ($selectedGeography.lad) {
-      $page.query.set("location", $selectedGeography.lad);
-      goto(`?${$page.query.toString()}`);
-      locationId = $page.query.get("location");
-      locationName = getLadName(locationId);
+      if ($selectedGeography.lad != locationId) {
+        $page.query.set("location", $selectedGeography.lad);
+        goto(`?${$page.query.toString()}`);
+        locationId = $page.query.get("location");
+        locationName = getLadName(locationId);
+      }
     }
   }
 

--- a/src/routes/[topicSlug]/[tableSlug]/[categorySlug].svelte
+++ b/src/routes/[topicSlug]/[tableSlug]/[categorySlug].svelte
@@ -84,11 +84,13 @@
 
   $: {
     if ($selectedGeography.lad) {
-      $page.query.set("location", $selectedGeography.lad);
-      goto(`?${$page.query.toString()}`);
-      locationId = $page.query.get("location");
-      geoCode = locationId;
-      locationName = getLadName(locationId);
+      if ($selectedGeography.lad != locationId) {
+        $page.query.set("location", $selectedGeography.lad);
+        goto(`?${$page.query.toString()}`);
+        locationId = $page.query.get("location");
+        geoCode = locationId;
+        locationName = getLadName(locationId);
+      }
     }
   }
   $: category = getCategoryBySlug(tableSlug, categorySlug);

--- a/src/routes/area/index.svelte
+++ b/src/routes/area/index.svelte
@@ -102,10 +102,12 @@
   }
   $: {
     if ($selectedGeography.lad) {
-      $page.query.set("location", $selectedGeography.lad);
-      goto(`?${$page.query.toString()}`);
-      locationId = $page.query.get("location");
-      locationName = getLadName(locationId);
+      if ($selectedGeography.lad != locationId) {
+        $page.query.set("location", $selectedGeography.lad);
+        goto(`?${$page.query.toString()}`);
+        locationId = $page.query.get("location");
+        locationName = getLadName(locationId);
+      }
     }
   }
 </script>

--- a/src/routes/topics/[topicSlug].svelte
+++ b/src/routes/topics/[topicSlug].svelte
@@ -20,13 +20,21 @@
 
   $: {
     locationId = $page.query.get("location");
+    updateSelectedGeography(locationId);
+    locationName = getLadName(locationId) ? getLadName(locationId) : "England and Wales";
+  }
+
+  $: {
     if ($selectedGeography.lad) {
-      $page.query.set("location", $selectedGeography.lad);
-      goto(`?${$page.query.toString()}`);
-      locationId = $page.query.get("location");
-      locationName = getLadName(locationId);
+      if ($selectedGeography.lad != locationId) {
+        $page.query.set("location", $selectedGeography.lad);
+        goto(`?${$page.query.toString()}`);
+        locationId = $page.query.get("location");
+        locationName = getLadName(locationId);
+      }
     }
   }
+
   $: appIsInitialised, $appIsInitialised && initialisePage();
   function initialisePage() {
     if (locationId) {

--- a/src/routes/topics/[topicSlug]/[tableSlug]/[categorySlug].svelte
+++ b/src/routes/topics/[topicSlug]/[tableSlug]/[categorySlug].svelte
@@ -19,15 +19,24 @@
   let locationName, header;
   let showChangeLocation = false;
   $: category = getCategoryBySlug(tableSlug, categorySlug);
+
   $: {
     locationId = $page.query.get("location");
+    updateSelectedGeography(locationId);
+    locationName = getLadName(locationId) ? getLadName(locationId) : "England and Wales";
+  }
+
+  $: {
     if ($selectedGeography.lad) {
-      $page.query.set("location", $selectedGeography.lad);
-      goto(`?${$page.query.toString()}`);
-      locationId = $page.query.get("location");
-      locationName = getLadName(locationId);
+      if ($selectedGeography.lad != locationId) {
+        $page.query.set("location", $selectedGeography.lad);
+        goto(`?${$page.query.toString()}`);
+        locationId = $page.query.get("location");
+        locationName = getLadName(locationId);
+      }
     }
   }
+
   $: appIsInitialised, $appIsInitialised && initialisePage();
   function initialisePage() {
     if (locationId) {

--- a/src/routes/topics/index.svelte
+++ b/src/routes/topics/index.svelte
@@ -21,11 +21,18 @@
 
   $: {
     locationId = $page.query.get("location");
+    updateSelectedGeography(locationId);
+    locationName = getLadName(locationId) ? getLadName(locationId) : "England and Wales";
+  }
+
+  $: {
     if ($selectedGeography.lad) {
-      $page.query.set("location", $selectedGeography.lad);
-      goto(`?${$page.query.toString()}`);
-      locationId = $page.query.get("location");
-      locationName = getLadName(locationId);
+      if ($selectedGeography.lad != locationId) {
+        $page.query.set("location", $selectedGeography.lad);
+        goto(`?${$page.query.toString()}`);
+        locationId = $page.query.get("location");
+        locationName = getLadName(locationId);
+      }
     }
   }
   $: appIsInitialised, $appIsInitialised && initialisePage();

--- a/src/routes/topics/index.svelte
+++ b/src/routes/topics/index.svelte
@@ -70,7 +70,7 @@
   </span>
 
   <div class="ons-u-mb-xl">
-    <TopicList />
+    <TopicList {locationId} />
   </div>
 
   <span slot="map">

--- a/src/ui/ChangeLocation/ChangeLocation.svelte
+++ b/src/ui/ChangeLocation/ChangeLocation.svelte
@@ -10,12 +10,12 @@
   let renderError = false;
   let invertTextColor = true;
 
+  $: locationQueryParam = locationId ? `?location=${locationId}` : "";
   $: href = $page.path;
 
   function submitFunction(ladInput, baseUrl) {
     if (reverseLadLookup[ladInput]) {
       goto(`${baseUrl}?location=${reverseLadLookup[ladInput]}`);
-      updateSelectedGeography(reverseLadLookup[ladInput]);
       onClose();
     } else {
       renderError = true;
@@ -27,7 +27,7 @@
 <div class={`ons-grid ons-grid--flex change-container ${isMobile ? "mobile" : ""}`}>
   <div class="ons-container">
     <div class="close-button">
-      <a class="close-link" {href} id="close" on:click={onClose}>Close </a>
+      <a class="close-link" href={href + locationQueryParam} id="close" on:click={onClose}>Close </a>
       <svg
         class="ons-svg-icon"
         width="19"

--- a/src/ui/TopicList.svelte
+++ b/src/ui/TopicList.svelte
@@ -1,10 +1,12 @@
 <script>
   import ONSCard from "./ons/ONSCard.svelte";
   import { censusMetadata } from "../model/metadata/metadata";
+  export let locationId;
+  $: locationQueryParam = locationId ? `?location=${locationId}` : "";
 </script>
 
 {#each $censusMetadata as topic, i}
-  <ONSCard title={topic.name} href="topics/{topic.slug}" id="topic-{i}">{topic.desc}</ONSCard>
+  <ONSCard title={topic.name} href="topics/{topic.slug}{locationQueryParam}" id="topic-{i}">{topic.desc}</ONSCard>
   {#if i < $censusMetadata.length - 1}
     <hr class="component-margin--2" />
   {/if}

--- a/src/ui/TopicList.svelte
+++ b/src/ui/TopicList.svelte
@@ -1,11 +1,11 @@
 <script>
   import ONSCard from "./ons/ONSCard.svelte";
-  import metadata from "../data/apiMetadata.js";
+  import { censusMetadata } from "../model/metadata/metadata";
 </script>
 
-{#each metadata as topic, i}
+{#each $censusMetadata as topic, i}
   <ONSCard title={topic.name} href="topics/{topic.slug}" id="topic-{i}">{topic.desc}</ONSCard>
-  {#if i < metadata.length - 1}
+  {#if i < $censusMetadata.length - 1}
     <hr class="component-margin--2" />
   {/if}
 {/each}


### PR DESCRIPTION
**What**

On some screens (the ones where the svelte `goto` function was used to update the location query parameter), it was needed two or three clicks of the browser back button to actually see a change in the url. This was basically a svelte reactivity issue, calling the `goto` function multiple times. The issue was fixed by checking first if the location query parameter is different from the current selected geography of the user (`$selectedGeography.lad != locationId`) , before calling the `goto` function.

The browser back button it wasn't working at all on all the `topics` routes - I've fixed that by adding some missing logic on those routes .

After clicking the  close button(hyperlink) of the ChangeLocation component the map was zooming out on England and Wales even if previously there was a geography selected - the issue was fixed by also checking if there is a location query parameter when building the `href` for the close hyperlink of the ChangeLocation component.

Small changes on the `TopicList` component.
